### PR TITLE
Restrict validation options by control type

### DIFF
--- a/Controllers/FormBuilderController.cs
+++ b/Controllers/FormBuilderController.cs
@@ -1,5 +1,6 @@
 ﻿using DynamicForm.Models;
 using DynamicForm.Service.Interface;
+using ClassLibrary;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DynamicForm.Controllers;
@@ -95,7 +96,11 @@ public class FormDesignerController : Controller
         {
             return BadRequest("請先設定控制元件後再新增驗證條件。");
         }
-        
+
+        var controlType = _formDesignerService.GetControlTypeByFieldId(fieldId);
+        var allowedValidations = ValidationRulesMap.GetValidations(controlType);
+        ViewBag.ValidationTypeOptions = EnumExtensions.ToSelectList(allowedValidations);
+
         List<FormFieldValidationRuleDto> rules = _formDesignerService.GetValidationRulesByFieldId(fieldId);
         return PartialView("SettingRule/_SettingRuleModal", rules);
     }
@@ -103,7 +108,7 @@ public class FormDesignerController : Controller
     [HttpPost]
     public IActionResult CreateEmptyValidationRule(Guid fieldConfigId,string VALIDATION_TYPE)
     {
-        var controlType = CONTROL_TYPE; // 假設轉成 Enum 了
+        var controlType = _formDesignerService.GetControlTypeByFieldId(fieldConfigId);
         var allowedValidations = ValidationRulesMap.GetValidations(controlType);
         ViewBag.ValidationTypeOptions = EnumExtensions.ToSelectList(allowedValidations);
         

--- a/Helper/EnumHelper.cs
+++ b/Helper/EnumHelper.cs
@@ -12,8 +12,19 @@ public static class EnumExtensions
             .Cast<TEnum>()
             .Select(e => new SelectListItem
             {
-                Value = Convert.ToInt32(e).ToString(),      
-                Text = GetDisplayName(e)                    
+                Value = Convert.ToInt32(e).ToString(),
+                Text = GetDisplayName(e)
+            })
+            .ToList();
+    }
+
+    public static List<SelectListItem> ToSelectList<TEnum>(IEnumerable<TEnum> values) where TEnum : Enum
+    {
+        return values
+            .Select(e => new SelectListItem
+            {
+                Value = Convert.ToInt32(e).ToString(),
+                Text = GetDisplayName(e)
             })
             .ToList();
     }

--- a/Service/Interface/IFormBuilderService.cs
+++ b/Service/Interface/IFormBuilderService.cs
@@ -1,4 +1,5 @@
-﻿using DynamicForm.Models;
+using DynamicForm.Models;
+using ClassLibrary;
 
 namespace DynamicForm.Service.Interface;
 
@@ -14,6 +15,8 @@ public interface IFormDesignerService
 
     void InsertValidationRule(FormFieldValidationRuleDto model);
     int GetNextValidationOrder(Guid fieldId);
+
+    FormControlType GetControlTypeByFieldId(Guid fieldId);
 
     bool SaveValidationRule(FormFieldValidationRuleDto rule);
 }

--- a/Service/Service/FormBuilderService.cs
+++ b/Service/Service/FormBuilderService.cs
@@ -171,6 +171,12 @@ public class FormDesignerService : IFormDesignerService
         return _con.ExecuteScalar<int>(sql, new { fieldId });
     }
 
+    public FormControlType GetControlTypeByFieldId(Guid fieldId)
+    {
+        const string sql = @"SELECT CONTROL_TYPE FROM FORM_FIELD_CONFIG WHERE ID = @fieldId";
+        return _con.ExecuteScalar<FormControlType>(sql, new { fieldId });
+    }
+
     
     public bool SaveValidationRule(FormFieldValidationRuleDto rule)
     {

--- a/Views/FormDesigner/SettingRule/_SettingRuleModal.cshtml
+++ b/Views/FormDesigner/SettingRule/_SettingRuleModal.cshtml
@@ -1,4 +1,10 @@
-﻿@model List<FormFieldValidationRuleDto>
+﻿@using ClassLibrary
+@using Microsoft.AspNetCore.Mvc.Rendering
+@model List<FormFieldValidationRuleDto>
+@{
+    var options = ViewBag.ValidationTypeOptions as List<SelectListItem> ?? EnumExtensions.ToSelectList<ValidationType>();
+    var viewData = new ViewDataDictionary(ViewData) { { "ValidationTypeOptions", options } };
+}
 
 <table class="table table-bordered table-sm align-middle">
     <thead class="table-light">
@@ -12,7 +18,7 @@
         </tr>
     </thead>
     <tbody id="validationRuleRow">
-        @await Html.PartialAsync("SettingRule/_ValidationRuleRow", Model)
+        @await Html.PartialAsync("SettingRule/_ValidationRuleRow", Model, viewData)
     </tbody>
 </table>
 

--- a/Views/FormDesigner/SettingRule/_ValidationRuleRow.cshtml
+++ b/Views/FormDesigner/SettingRule/_ValidationRuleRow.cshtml
@@ -1,5 +1,9 @@
 ﻿@using ClassLibrary
+@using Microsoft.AspNetCore.Mvc.Rendering
 @model List<FormFieldValidationRuleDto>
+@{
+    var options = ViewData["ValidationTypeOptions"] as List<SelectListItem> ?? EnumExtensions.ToSelectList<ValidationType>();
+}
 
 @if (Model.Any())
 {
@@ -10,7 +14,7 @@
                 <select class="form-select form-select-sm validation-type"
                         name="VALIDATION_TYPE"
                         disabled>
-                    @foreach (var item in EnumExtensions.ToSelectList<ValidationType>())
+                    @foreach (var item in options)
                     {
                         var selected = item.Value == rule.VALIDATION_TYPE ? "selected" : null;
                         <option value="@item.Value" selected="@selected">@item.Text</option>


### PR DESCRIPTION
## Summary
- map control type to allowed validation types for new rule modal
- expose method to fetch field control type
- add enum helper overload to create select lists from allowed enum values
- pass allowed validation types to partial views

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6881bc8311ec8320bc32970b22313724