### PR TITLE
Add dropdown option configuration

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -3,6 +3,7 @@ using DynamicForm.Models;
 using DynamicForm.Service.Interface;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Collections.Generic;
 
 namespace DynamicForm.Controllers;
 
@@ -107,6 +108,33 @@ public class FormDesignerController : Controller
 
         var rules = _formDesignerService.GetValidationRulesByFieldId(fieldConfigId);
         return PartialView("SettingRule/_ValidationRuleRow", rules);
+    }
+
+    [HttpPost]
+    public IActionResult DropdownSetting(Guid fieldId)
+    {
+        var setting = _formDesignerService.GetDropdownSetting(fieldId);
+        return PartialView("Dropdown/_DropdownModal", setting);
+    }
+
+    [HttpPost]
+    public IActionResult SaveDropdownSql(Guid fieldId, string sql)
+    {
+        _formDesignerService.SaveDropdownSql(fieldId, sql);
+        return Json(new { success = true });
+    }
+
+    [HttpPost]
+    public IActionResult SaveDropdownOptions([FromBody] DropdownOptionPostModel model)
+    {
+        _formDesignerService.SaveDropdownOptions(model.FieldId, model.Options);
+        return Json(new { success = true });
+    }
+
+    public class DropdownOptionPostModel
+    {
+        public Guid FieldId { get; set; }
+        public List<string> Options { get; set; } = new();
     }
 
     private List<SelectListItem> GetValidationTypeOptions(Guid fieldId)

--- a/Models/DropdownSettingDto.cs
+++ b/Models/DropdownSettingDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace DynamicForm.Models;
+
+public class DropdownSettingDto
+{
+    public bool IsUseSql { get; set; }
+    public string DropdownSql { get; set; } = string.Empty;
+    public List<FormFieldValidationRuleDropdownDto> Options { get; set; } = new();
+}

--- a/Models/FormFieldValidationRuleDropdownDto.cs
+++ b/Models/FormFieldValidationRuleDropdownDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace DynamicForm.Models;
+
+public class FormFieldValidationRuleDropdownDto
+{
+    public Guid ID { get; set; }
+    public Guid FORM_FIELD_VALIDATION_RULE_ID { get; set; }
+    public string OPTION_TEXT { get; set; } = string.Empty;
+}

--- a/Models/FormFieldValidationRuleDto.cs
+++ b/Models/FormFieldValidationRuleDto.cs
@@ -9,4 +9,8 @@ public class FormFieldValidationRuleDto
     public string MESSAGE_ZH { get; set; }
     public string MESSAGE_EN { get; set; }
     public int VALIDATION_ORDER { get; set; }
+
+    public bool IS_USE_DROPDOWN_SQL { get; set; }
+
+    public string DROPDOWN_SQL { get; set; } = string.Empty;
 }

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -24,4 +24,9 @@ public interface IFormDesignerService
     bool SaveValidationRule(FormFieldValidationRuleDto rule);
 
     bool DeleteValidationRule(Guid id);
+
+    // Dropdown option related
+    DropdownSettingDto GetDropdownSetting(Guid fieldId);
+    void SaveDropdownSql(Guid fieldId, string sql);
+    void SaveDropdownOptions(Guid fieldId, IEnumerable<string> options);
 }

--- a/Views/FormDesigner/Dropdown/_DropdownModal.cshtml
+++ b/Views/FormDesigner/Dropdown/_DropdownModal.cshtml
@@ -1,0 +1,80 @@
+@model DropdownSettingDto
+
+<div class="mb-3">
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="mode" id="modeSql" value="sql" @(Model.IsUseSql ? "checked" : "")>
+        <label class="form-check-label" for="modeSql">
+            使用 SQL 取得選項
+        </label>
+    </div>
+    <textarea class="form-control mt-2" id="dropdownSql" rows="3" @(Model.IsUseSql ? "" : "disabled")>@Model.DropdownSql</textarea>
+</div>
+<div class="mb-3">
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="mode" id="modeManual" value="manual" @(Model.IsUseSql ? "" : "checked")>
+        <label class="form-check-label" for="modeManual">
+            手動輸入選項
+        </label>
+    </div>
+    <ul class="list-group mt-2" id="optionList">
+        @foreach (var opt in Model.Options)
+        {
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <input type="text" class="form-control option-text" value="@opt.OPTION_TEXT" />
+                <button type="button" class="btn btn-sm btn-outline-danger ms-2 remove-opt">刪除</button>
+            </li>
+        }
+    </ul>
+    <button type="button" class="btn btn-sm btn-success mt-2" id="addOption">新增選項</button>
+</div>
+<div class="text-end">
+    <button type="button" class="btn btn-primary" id="saveDropdown">儲存</button>
+</div>
+
+<script>
+    $(function () {
+        function toggleMode() {
+            const mode = $('input[name="mode"]:checked').val();
+            if (mode === 'sql') {
+                $('#dropdownSql').prop('disabled', false);
+                $('#optionList').find('input').prop('disabled', true);
+                $('#addOption').prop('disabled', true);
+            } else {
+                $('#dropdownSql').prop('disabled', true);
+                $('#optionList').find('input').prop('disabled', false);
+                $('#addOption').prop('disabled', false);
+            }
+        }
+        toggleMode();
+        $('input[name="mode"]').change(toggleMode);
+
+        $('#addOption').click(function(){
+            $('#optionList').append('<li class="list-group-item d-flex justify-content-between align-items-center"><input type="text" class="form-control option-text" /><button type="button" class="btn btn-sm btn-outline-danger ms-2 remove-opt">刪除</button></li>');
+        });
+        $(document).on('click','.remove-opt', function(){
+            $(this).closest('li').remove();
+        });
+
+        $('#saveDropdown').click(function(){
+            const mode = $('input[name="mode"]:checked').val();
+            const fieldId = $('#ID').val();
+            if (mode === 'sql') {
+                const sql = $('#dropdownSql').val();
+                $.post('/FormDesigner/SaveDropdownSql', { fieldId: fieldId, sql: sql })
+                    .done(() => $('.closeModal').click());
+            } else {
+                const opts = [];
+                $('#optionList .option-text').each(function(){
+                    const val = $(this).val();
+                    if (val) opts.push(val);
+                });
+                $.ajax({
+                    url: '/FormDesigner/SaveDropdownOptions',
+                    type: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify({ fieldId: fieldId, options: opts })
+                }).done(() => $('.closeModal').click());
+            }
+        });
+    });
+</script>

--- a/Views/FormDesigner/_FormFieldSetting.cshtml
+++ b/Views/FormDesigner/_FormFieldSetting.cshtml
@@ -79,6 +79,14 @@
                     設定限制條件
                 </button>
             </div>
+            <div class="col-md-4 d-flex align-items-center">
+                <button type="button"
+                        class="btn btn-outline-secondary btn-sm setting-dropdown-btn @(Model?.CONTROL_TYPE == FormControlType.Dropdown ? "" : "d-none")"
+                        data-id="@Model?.ID"
+                        @(Model == null ? "disabled" : "")>
+                    下拉選單設定
+                </button>
+            </div>
 
         </div>
 </fieldset>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -32,12 +32,24 @@ function loadFieldSetting(tableName, columnName) {
         data: { tableName: tableName, columnName: columnName },
         success: function (html) {
             $('#formFieldSetting').html(html);
+            toggleDropdownButton();
         },
         error: function () {
             alert('載入欄位設定失敗');
         }
     });
 }
+
+function toggleDropdownButton() {
+    const val = $('#CONTROL_TYPE').val();
+    if (val == '5') {
+        $('.setting-dropdown-btn').removeClass('d-none');
+    } else {
+        $('.setting-dropdown-btn').addClass('d-none');
+    }
+}
+
+$(document).on('change', '#CONTROL_TYPE', toggleDropdownButton);
 
 /*
 * 更新設定
@@ -214,6 +226,18 @@ $(document).on('click', '.delete-rule', function () {
             }
         });
     });
+});
+
+$(document).on('click', '.setting-dropdown-btn', function () {
+    const id = $(this).data('id');
+    if (!id) return;
+
+    $.post('/FormDesigner/DropdownSetting', { fieldId: id })
+        .done(function (html) {
+            $(".modal-title").text("下拉選單設定");
+            $("#settingRuleModalBody").html(html);
+            $("#settingRuleModal").modal({ backdrop: "static" }).modal('show');
+        });
 });
 
 $(document).on('click', '.closeModal', function () {


### PR DESCRIPTION
## Summary
- allow dropdown modal for fields in FormDesigner
- store dropdown options and SQL in new DTOs and services
- expose endpoints to manage dropdown options
- enable button on FormFieldSetting to open dropdown configuration

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688203e8296883209867de94c6187942