### PR TITLE
Ensure fields persisted on search

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -30,8 +30,8 @@ public class FormDesignerController : Controller
     [HttpGet]
     public IActionResult QueryFields(string tableName)
     {
-        FormFieldListViewModel result = _formDesignerService.GetFieldsByTableName(tableName);
-        
+        FormFieldListViewModel result = _formDesignerService.EnsureFieldsSaved(tableName);
+
         return PartialView("_FormFieldList", result);
     }
     


### PR DESCRIPTION
## Summary
- save missing form field configs when searching by table name
- adjust controller to use the new service method

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688347c7dc4483208f0c65f6452aa7b4