### PR TITLE
Fix form master creation values

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -48,7 +48,8 @@ public class FormDesignerController : Controller
     public IActionResult UpdateFieldSetting(FormFieldViewModel model)
     {
         // 1. 取得 FORM_FIELD_Master ID，如果不存在就新增
-        var formMasterId = _formDesignerService.GetOrCreateFormMasterId(model.FORM_FIELD_Master_ID);
+        var master = new FORM_FIELD_Master { ID = model.FORM_FIELD_Master_ID };
+        var formMasterId = _formDesignerService.GetOrCreateFormMasterId(master);
         
         // 2. 驗證控制類型變更是否合法（不能改已有驗證規則的欄位）
         if (_formDesignerService.HasValidationRules(model.ID) &&

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -27,12 +27,18 @@ public class FormDesignerService : IFormDesignerService
         if (res.HasValue)
             return res.Value;
 
-        var newId = Guid.NewGuid();
+        var insertId = model.ID == Guid.Empty ? Guid.NewGuid() : model.ID;
         _con.Execute(@"
         INSERT INTO FORM_FIELD_Master (ID, FORM_NAME, STATUS, SCHEMA_TYPE)
-        VALUES (@ID, @FORM_NAME, @STATUS, @SCHEMA_TYPE)", new { ID = newId, model.FORM_NAME, model.STATUS, model.SCHEMA_TYPE });
+        VALUES (@ID, @FORM_NAME, @STATUS, @SCHEMA_TYPE)", new
+        {
+            ID = insertId,
+            model.FORM_NAME,
+            model.STATUS,
+            model.SCHEMA_TYPE
+        });
 
-        return newId;
+        return insertId;
     }
 
     /// <summary>
@@ -90,7 +96,12 @@ public class FormDesignerService : IFormDesignerService
         var columns = GetTableSchema(tableName, schemaType);
         if (columns.Count == 0) return new();
 
-        FORM_FIELD_Master model = new FORM_FIELD_Master();
+        FORM_FIELD_Master model = new FORM_FIELD_Master
+        {
+            FORM_NAME = tableName,
+            STATUS = (int)TableStatusType.Draft,
+            SCHEMA_TYPE = (int)schemaType
+        };
         var configs = GetFieldConfigs(tableName);
         var masterId = configs.Values.FirstOrDefault()?.FORM_FIELD_Master_ID
                        ?? GetOrCreateFormMasterId(model);


### PR DESCRIPTION
## Summary
- ensure GetOrCreateFormMasterId inserts supplied ID when creating
- populate default STATUS and SCHEMA_TYPE when ensuring fields
- create FORM_FIELD_Master model when updating field settings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f57099d48320afc53edcc367c7a7