### PR TITLE
新增儲存表單主檔 API

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -168,8 +168,36 @@ public class FormDesignerController : Controller
     public IActionResult ValidateDropdownSql(string sql)
     {
         var res = _formDesignerService.ValidateDropdownSql(sql);
-       
+
         return PartialView("Dropdown/_ValidateSqlResult", res);
+    }
+
+    [HttpPost]
+    public IActionResult SaveFormHeader([FromBody] FormHeaderViewModel model)
+    {
+        if (string.IsNullOrWhiteSpace(model.TABLE_NAME))
+        {
+            return BadRequest("BASE_TABLE_NAME 不可為空");
+        }
+
+        if (string.IsNullOrWhiteSpace(model.DISPLAY_VIEW_NAME))
+        {
+            return BadRequest("VIEW_NAME 不可為空");
+        }
+
+        var master = new FORM_FIELD_Master
+        {
+            FORM_NAME = model.FORM_NAME,
+            BASE_TABLE_NAME = model.TABLE_NAME,
+            VIEW_NAME = model.DISPLAY_VIEW_NAME,
+            PRIMARY_KEY = string.Empty,
+            STATUS = (int)TableStatusType.Draft,
+            SCHEMA_TYPE = (int)TableSchemaQueryType.All
+        };
+
+        _formDesignerService.SaveFormHeader(master);
+
+        return Json(new { success = true });
     }
     
     private List<SelectListItem> GetValidationTypeOptions(Guid fieldId)

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -42,5 +42,6 @@ public interface IFormDesignerService
     void SetDropdownMode(Guid dropdownId, bool isUseSql);
 
     ValidateSqlResultViewModel ValidateDropdownSql(string sql);
+    Guid SaveFormHeader(FORM_FIELD_Master model);
     // void NewDropdownOption(Guid dropdownId);
 }

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -353,6 +353,18 @@ public class FormDesignerService : IFormDesignerService
         return result;
     }
 
+    public Guid SaveFormHeader(FORM_FIELD_Master model)
+    {
+        // 若不存在則產生新 ID
+        if (model.ID == Guid.Empty)
+        {
+            model.ID = Guid.NewGuid();
+        }
+
+        var id = _con.ExecuteScalar<Guid>(Sql.UpsertFormMaster, model);
+        return id;
+    }
+
 
     #endregion
 
@@ -407,13 +419,27 @@ FROM FORM_FIELD_VALIDATION_RULE";
 
         public const string TableSchemaSelect = @"/**/
 SELECT COLUMN_NAME, DATA_TYPE, ORDINAL_POSITION
-FROM INFORMATION_SCHEMA.COLUMNS 
+FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_NAME = @TableName
   AND (
       (@Type = 0 AND TABLE_NAME NOT LIKE 'V_%')
       OR (@Type = 1 AND TABLE_NAME LIKE 'V_%')
   )
 ORDER BY ORDINAL_POSITION";
+
+        public const string UpsertFormMaster = @"/**/
+MERGE FORM_FIELD_Master AS target
+USING (SELECT @FORM_NAME AS FORM_NAME) AS src
+ON target.FORM_NAME = src.FORM_NAME
+WHEN MATCHED THEN
+    UPDATE SET
+        BASE_TABLE_NAME = @BASE_TABLE_NAME,
+        VIEW_NAME       = @VIEW_NAME,
+        PRIMARY_KEY     = @PRIMARY_KEY
+WHEN NOT MATCHED THEN
+    INSERT (FORM_NAME, BASE_TABLE_NAME, VIEW_NAME, PRIMARY_KEY, STATUS, SCHEMA_TYPE)
+    VALUES (@FORM_NAME, @BASE_TABLE_NAME, @VIEW_NAME, @PRIMARY_KEY, @STATUS, @SCHEMA_TYPE)
+OUTPUT INSERTED.ID;";
         
         public const string UpsertField = @"
 MERGE FORM_FIELD_CONFIG AS target

--- a/Views/FormDesigner/_FormHeader.cshtml
+++ b/Views/FormDesigner/_FormHeader.cshtml
@@ -24,6 +24,9 @@
             <button class="btn btn-info" type="button" id="btnSearchViewTable">
                 <i class="bi bi-search"></i> 搜尋
             </button>
+            <button class="btn btn-primary" type="button" id="btnSaveFormHeader">
+                <i class="bi bi-save"></i> 儲存
+            </button>
         </div>
     </div>
 </div>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -37,6 +37,28 @@ $('#btnSearchViewTable').click(function () {
     handleTableSearch('#viewTableNameInput', 'viewTableName', '#formViewFieldList');
 });
 
+// 儲存 Form Header
+$('#btnSaveFormHeader').click(function () {
+    const data = {
+        FORM_NAME: $('#FORM_NAME').val(),
+        TABLE_NAME: $('#tableNameInput').val(),
+        DISPLAY_VIEW_NAME: $('#viewTableNameInput').val()
+    };
+
+    $.ajax({
+        url: '/FormDesigner/SaveFormHeader',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        success: function () {
+            alert('儲存成功');
+        },
+        error: function (xhr) {
+            alert(xhr.responseText || '儲存失敗');
+        }
+    });
+});
+
 
 /*
 * 載入單一欄位詳細資料設定


### PR DESCRIPTION
## Summary
- add Save button for view name and bind save event
- implement `SaveFormHeader` API with server-side validation
- expose API in `IFormDesignerService` and implement logic in service
- add SQL to upsert form master record

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6885cef39b4c8320986b09062d2b0e60