### PR TITLE
Fix hidden IDs for form master

### DIFF
--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -76,13 +76,16 @@ public class FormDesignerService : IFormDesignerService
                 DEFAULT_VALUE          = cfg?.DEFAULT_VALUE ??  string.Empty
             };
         }).ToList();
+        var masterId = configs.Values.FirstOrDefault()?.FORM_FIELD_Master_ID ?? Guid.Empty;
 
         var result = new FormFieldListViewModel
         {
+            ID = masterId,
             TableName = tableName,
-            Fields = res
+            Fields = res,
+            type = schemaType
         };
-        
+
         return result;
     }
 
@@ -127,7 +130,9 @@ public class FormDesignerService : IFormDesignerService
             }
         }
 
-        return GetFieldsByTableName(tableName, schemaType);
+        var result = GetFieldsByTableName(tableName, schemaType);
+        result.type = schemaType;
+        return result;
     }
 
     /// <summary>

--- a/Views/FormDesigner/_FormFieldList.cshtml
+++ b/Views/FormDesigner/_FormFieldList.cshtml
@@ -3,7 +3,7 @@
 @using ClassLibrary
 @model FormFieldListViewModel?
 
-<div style="max-height: 400px; overflow-y: auto;">
+<div style="max-height: 400px; overflow-y: auto;" data-master-id="@Model?.ID">
     <table class="table table-bordered table-striped table-hover align-middle text-sm w-100" style="table-layout: fixed;">
         <thead class="table-light" style="position: sticky; top: 0; z-index: 5;">
         <tr>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -21,6 +21,12 @@ function handleTableSearch(inputSelector, nameKey, targetSelector) {
         data: data,
         success: function (partialHtml) {
             $(targetSelector).html(partialHtml); // 指定要更新的區塊
+            const masterId = $(targetSelector).find('[data-master-id]').data('master-id');
+            if (nameKey === 'tableName') {
+                $('#baseTableId').val(masterId);
+            } else {
+                $('#viewTableId').val(masterId);
+            }
         },
         error: function () {
             alert('查詢失敗，請確認表格名稱');


### PR DESCRIPTION
## Summary
- store master ID when querying fields
- expose master ID via `_FormFieldList` markup
- update JS to capture ID and populate hidden inputs

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f95beec08320b9b2e4aa72243b44