### PR TITLE
Handle unset control types

### DIFF
--- a/Helper/FormFieldHelper.cs
+++ b/Helper/FormFieldHelper.cs
@@ -15,6 +15,17 @@ public static class FormFieldHelper
         { "default",  new() { FormControlType.Text, FormControlType.Textarea } }
     };
 
+    private static readonly Dictionary<string, FormControlType> DefaultControlTypeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "datetime", FormControlType.Date },
+        { "bit",      FormControlType.Checkbox },
+        { "int",      FormControlType.Number },
+        { "decimal",  FormControlType.Number },
+        { "nvarchar", FormControlType.Text },
+        { "varchar",  FormControlType.Text },
+        { "default",  FormControlType.Text }
+    };
+
     public static List<FormControlType> GetControlTypeWhitelist(string dataType)
     {
         return ControlTypeWhitelistMap.TryGetValue(dataType, out var list)
@@ -32,5 +43,12 @@ public static class FormFieldHelper
             "int" or "decimal" => 100,
             _ => 150
         };
+    }
+
+    public static FormControlType GetDefaultControlType(string dataType)
+    {
+        return DefaultControlTypeMap.TryGetValue(dataType, out var type)
+            ? type
+            : DefaultControlTypeMap["default"];
     }
 }

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -120,6 +120,7 @@ public class FormDesignerService : IFormDesignerService
                     TableName = tableName,
                     COLUMN_NAME = col.COLUMN_NAME,
                     DATA_TYPE = col.DATA_TYPE,
+                    CONTROL_TYPE = FormFieldHelper.GetDefaultControlType(col.DATA_TYPE),
                     IS_VISIBLE = true,
                     IS_EDITABLE = true,
                     EDITOR_WIDTH = FormFieldHelper.GetDefaultEditorWidth(col.DATA_TYPE),
@@ -141,13 +142,15 @@ public class FormDesignerService : IFormDesignerService
     /// <param name="model">表單欄位的 ViewModel</param>
     public void UpsertField(FormFieldViewModel model, Guid formMasterId)
     {
+        var controlType = model.CONTROL_TYPE ?? FormFieldHelper.GetDefaultControlType(model.DATA_TYPE);
+
         var param = new
         {
             ID = model.ID == Guid.Empty ? Guid.NewGuid() : model.ID,
             FORM_FIELD_Master_ID = formMasterId,
             TABLE_NAME = model.TableName,
             model.COLUMN_NAME,
-            model.CONTROL_TYPE,
+            CONTROL_TYPE = controlType,
             model.IS_VISIBLE,
             model.IS_EDITABLE,
             COLUMN_SPAN = model.EDITOR_WIDTH,


### PR DESCRIPTION
## Summary
- ensure new field configs always store a default control type
- expose helper to return default control type

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 - current SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6886130ba10c8320920a48d970f4bf7b