### PR TITLE
Use MVC unobtrusive Ajax for field list refresh

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -66,12 +66,16 @@ public class FormDesignerController : Controller
     {
         FormFieldViewModel? field = _formDesignerService.GetFieldsByTableName(tableName, schemaType).Fields
                        .FirstOrDefault(x => x.COLUMN_NAME == columnName);
-        
+        if (field != null)
+        {
+            field.SchemaType = schemaType;
+        }
+        ViewBag.SchemaType = schemaType;
         return PartialView("_FormFieldSetting", field);
     }
     
     [HttpPost]
-    public IActionResult UpdateFieldSetting(FormFieldViewModel model)
+    public IActionResult UpdateFieldSetting(FormFieldViewModel model, TableSchemaQueryType schemaType)
     {
         // 1. 取得 FORM_FIELD_Master ID，如果不存在就新增
         var master = new FORM_FIELD_Master { ID = model.FORM_FIELD_Master_ID };
@@ -85,7 +89,10 @@ public class FormDesignerController : Controller
         }
         
         _formDesignerService.UpsertField(model, formMasterId);
-        return Json(new { success = true });
+        var fields = _formDesignerService.EnsureFieldsSaved(model.TableName, schemaType);
+        fields.ID = formMasterId;
+        fields.type = schemaType;
+        return PartialView("_FormFieldList", fields);
     }
 
     [HttpGet]

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -74,7 +74,8 @@ public class FormDesignerService : IFormDesignerService
                 IS_EDITABLE            = cfg?.IS_EDITABLE ?? true,
                 IS_VALIDATION_RULE     = requiredFieldIds.Contains(fieldId),
                 EDITOR_WIDTH           = cfg?.COLUMN_SPAN ?? FormFieldHelper.GetDefaultEditorWidth(dataType),
-                DEFAULT_VALUE          = cfg?.DEFAULT_VALUE ??  string.Empty
+                DEFAULT_VALUE          = cfg?.DEFAULT_VALUE ??  string.Empty,
+                SchemaType             = schemaType
             };
         }).ToList();
         var masterId = configs.Values.FirstOrDefault()?.FORM_FIELD_Master_ID ?? Guid.Empty;
@@ -127,7 +128,8 @@ public class FormDesignerService : IFormDesignerService
                     IS_VISIBLE = true,
                     IS_EDITABLE = true,
                     EDITOR_WIDTH = FormFieldHelper.GetDefaultEditorWidth(col.DATA_TYPE),
-                    DEFAULT_VALUE = string.Empty
+                    DEFAULT_VALUE = string.Empty,
+                    SchemaType = schemaType
                 };
 
                 UpsertField(vm, masterId);

--- a/ViewModels/FormDesignerViewModel.cs
+++ b/ViewModels/FormDesignerViewModel.cs
@@ -130,4 +130,9 @@ public class FormFieldViewModel
     /// 控制選擇白名單
     /// </summary>
     public List<FormControlType> CONTROL_TYPE_WHITELIST { get; set; } = new();
+
+    /// <summary>
+    /// 資料表查詢類型，更新欄位設定後重新載入清單時使用
+    /// </summary>
+    public TableSchemaQueryType SchemaType { get; set; }
 }

--- a/Views/FormDesigner/_FormFieldSetting.cshtml
+++ b/Views/FormDesigner/_FormFieldSetting.cshtml
@@ -4,12 +4,16 @@
 @model FormFieldViewModel?
 @{
     var isDisabled = Model == null;
+    var schemaType = Model?.SchemaType ?? (ViewBag.SchemaType != null ? (TableSchemaQueryType)ViewBag.SchemaType : TableSchemaQueryType.OnlyTable);
+    var updateTarget = schemaType == TableSchemaQueryType.OnlyView ? "#formViewFieldList" : "#formFieldList";
 }
-<form id="field-setting-form">
+<form id="field-setting-form" asp-action="UpdateFieldSetting" asp-controller="FormDesigner"
+      data-ajax="true" data-ajax-method="post" data-ajax-mode="replace" data-ajax-update="@updateTarget">
 <fieldset @(isDisabled ? "disabled" : "")>
     <input type="hidden" asp-for="TableName" />
     <input type="hidden" asp-for="ID" />
     <input type="hidden" asp-for="FORM_FIELD_Master_ID" />
+    <input type="hidden" asp-for="SchemaType" value="@schemaType" />
         <div class="row g-3">
             <div class="col-md-6">
                 <label asp-for="COLUMN_NAME" class="form-label">欄位名稱</label>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -49,6 +49,7 @@
     </div>
 </footer>
 <script src="~/lib/jquery/dist/jquery.min.js"></script>
+<script src="~/lib/jquery/jquery.unobtrusive-ajax.js"></script>
 <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <script src="~/js/site.js" asp-append-version="true"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -106,25 +106,7 @@ $(document).on('change', '#CONTROL_TYPE', toggleDropdownButton);
 * 更新設定
 * */
 $(document).on('change', '#field-setting-form input, #field-setting-form select', function () {
-    const formData = $('#field-setting-form').serialize();
-    console.log('Form changed:', formData);
-
-    $.ajax({
-        url: '/FormDesigner/UpdateFieldSetting',
-        type: 'POST',
-        data: formData,
-        success: function () {
-            // Swal.fire({
-            //     icon: 'success',
-            //     title: '儲存成功',
-            //     showConfirmButton: false,
-            //     timer: 1500
-            // });
-        },
-        error: function (xhr) {
-            alert('儲存失敗：' + xhr.responseText);
-        }
-    });
+    $('#field-setting-form').submit(); // 交由 MVC unobtrusive Ajax 處理
 });
 
 /*

--- a/wwwroot/lib/jquery/jquery.unobtrusive-ajax.js
+++ b/wwwroot/lib/jquery/jquery.unobtrusive-ajax.js
@@ -1,0 +1,205 @@
+// Unobtrusive Ajax support library for jQuery
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// @version <placeholder>
+// 
+// Microsoft grants you the right to use these script files for the sole
+// purpose of either: (i) interacting through your browser with the Microsoft
+// website or online service, subject to the applicable licensing or use
+// terms; or (ii) using the files as included with a Microsoft product subject
+// to that product's license terms. Microsoft reserves all other rights to the
+// files not expressly granted by Microsoft, whether by implication, estoppel
+// or otherwise. Insofar as a script file is dual licensed under GPL,
+// Microsoft neither took the code under GPL nor distributes it thereunder but
+// under the terms set out in this paragraph. All notices and licenses
+// below are for informational purposes only.
+
+/*jslint white: true, browser: true, onevar: true, undef: true, nomen: true, eqeqeq: true, plusplus: true, bitwise: true, regexp: true, newcap: true, immed: true, strict: false */
+/*global window: false, jQuery: false */
+
+(function ($) {
+    var data_click = "unobtrusiveAjaxClick",
+        data_target = "unobtrusiveAjaxClickTarget",
+        data_validation = "unobtrusiveValidation";
+
+    function getFunction(code, argNames) {
+        var fn = window, parts = (code || "").split(".");
+        while (fn && parts.length) {
+            fn = fn[parts.shift()];
+        }
+        if (typeof (fn) === "function") {
+            return fn;
+        }
+        argNames.push(code);
+        return Function.constructor.apply(null, argNames);
+    }
+
+    function isMethodProxySafe(method) {
+        return method === "GET" || method === "POST";
+    }
+
+    function asyncOnBeforeSend(xhr, method) {
+        if (!isMethodProxySafe(method)) {
+            xhr.setRequestHeader("X-HTTP-Method-Override", method);
+        }
+    }
+
+    function asyncOnSuccess(element, data, contentType) {
+        var mode;
+
+        if (contentType.indexOf("application/x-javascript") !== -1) {  // jQuery already executes JavaScript for us
+            return;
+        }
+
+        mode = (element.getAttribute("data-ajax-mode") || "").toUpperCase();
+        $(element.getAttribute("data-ajax-update")).each(function (i, update) {
+            var top;
+
+            switch (mode) {
+                case "BEFORE":
+                    $(update).prepend(data);
+                    break;
+                case "AFTER":
+                    $(update).append(data);
+                    break;
+                case "REPLACE-WITH":
+                    $(update).replaceWith(data);
+                    break;
+                default:
+                    $(update).html(data);
+                    break;
+            }
+        });
+    }
+
+    function asyncRequest(element, options) {
+        var confirm, loading, method, duration;
+
+        confirm = element.getAttribute("data-ajax-confirm");
+        if (confirm && !window.confirm(confirm)) {
+            return;
+        }
+
+        loading = $(element.getAttribute("data-ajax-loading"));
+        duration = parseInt(element.getAttribute("data-ajax-loading-duration"), 10) || 0;
+
+        $.extend(options, {
+            type: element.getAttribute("data-ajax-method") || undefined,
+            url: element.getAttribute("data-ajax-url") || undefined,
+            cache: (element.getAttribute("data-ajax-cache") || "").toLowerCase() === "true",
+            beforeSend: function (xhr) {
+                var result;
+                asyncOnBeforeSend(xhr, method);
+                result = getFunction(element.getAttribute("data-ajax-begin"), ["xhr"]).apply(element, arguments);
+                if (result !== false) {
+                    loading.show(duration);
+                }
+                return result;
+            },
+            complete: function () {
+                loading.hide(duration);
+                getFunction(element.getAttribute("data-ajax-complete"), ["xhr", "status"]).apply(element, arguments);
+            },
+            success: function (data, status, xhr) {
+                asyncOnSuccess(element, data, xhr.getResponseHeader("Content-Type") || "text/html");
+                getFunction(element.getAttribute("data-ajax-success"), ["data", "status", "xhr"]).apply(element, arguments);
+            },
+            error: function () {
+                getFunction(element.getAttribute("data-ajax-failure"), ["xhr", "status", "error"]).apply(element, arguments);
+            }
+        });
+
+        options.data.push({ name: "X-Requested-With", value: "XMLHttpRequest" });
+
+        method = options.type.toUpperCase();
+        if (!isMethodProxySafe(method)) {
+            options.type = "POST";
+            options.data.push({ name: "X-HTTP-Method-Override", value: method });
+        }
+
+        // change here:
+        // Check for a Form POST with enctype=multipart/form-data
+        // add the input file that were not previously included in the serializeArray()
+        // set processData and contentType to false
+        var $element = $(element);
+        if ($element.is("form") && $element.attr("enctype") == "multipart/form-data") {
+            var formdata = new FormData();
+            $.each(options.data, function (i, v) {
+                formdata.append(v.name, v.value);
+            });
+            $("input[type=file]", $element).each(function () {
+                var file = this;
+                $.each(file.files, function (n, v) {
+                    formdata.append(file.name, v);
+                });
+            });
+            $.extend(options, {
+                processData: false,
+                contentType: false,
+                data: formdata
+            });
+        }
+        // end change
+
+        $.ajax(options);
+    }
+
+    function validate(form) {
+        var validationInfo = $(form).data(data_validation);
+        return !validationInfo || !validationInfo.validate || validationInfo.validate();
+    }
+
+    $(document).on("click", "a[data-ajax=true]", function (evt) {
+        evt.preventDefault();
+        asyncRequest(this, {
+            url: this.href,
+            type: "GET",
+            data: []
+        });
+    });
+
+    $(document).on("click", "form[data-ajax=true] input[type=image]", function (evt) {
+        var name = evt.target.name,
+            target = $(evt.target),
+            form = $(target.parents("form")[0]),
+            offset = target.offset();
+
+        form.data(data_click, [
+            { name: name + ".x", value: Math.round(evt.pageX - offset.left) },
+            { name: name + ".y", value: Math.round(evt.pageY - offset.top) }
+        ]);
+
+        setTimeout(function () {
+            form.removeData(data_click);
+        }, 0);
+    });
+
+    $(document).on("click", "form[data-ajax=true] :submit", function (evt) {
+        var name = evt.currentTarget.name,
+            target = $(evt.target),
+            form = $(target.parents("form")[0]);
+
+        form.data(data_click, name ? [{ name: name, value: evt.currentTarget.value }] : []);
+        form.data(data_target, target);
+
+        setTimeout(function () {
+            form.removeData(data_click);
+            form.removeData(data_target);
+        }, 0);
+    });
+
+    $(document).on("submit", "form[data-ajax=true]", function (evt) {
+        var clickInfo = $(this).data(data_click) || [],
+            clickTarget = $(this).data(data_target),
+            isCancel = clickTarget && (clickTarget.hasClass("cancel") || clickTarget.attr('formnovalidate') !== undefined);
+        evt.preventDefault();
+        if (!isCancel && !validate(this)) {
+            return;
+        }
+        asyncRequest(this, {
+            url: this.action,
+            type: this.method || "GET",
+            data: clickInfo.concat($(this).serializeArray())
+        });
+    });
+}(jQuery));


### PR DESCRIPTION
## Summary
- add `jquery.unobtrusive-ajax.js` and include it in layout
- extend `FormFieldViewModel` with `SchemaType`
- refresh field list via unobtrusive AJAX form
- return partial view from `UpdateFieldSetting`
- simplify JS to let MVC handle the update

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68862a5001b08320b2ff8093b3a34cb4