### PR TITLE
Adjust validation rules visibility

### DIFF
--- a/Helper/ValidationRulesMapHelper.cs
+++ b/Helper/ValidationRulesMapHelper.cs
@@ -4,16 +4,21 @@ public static class ValidationRulesMap
 {
     private static readonly Dictionary<FormControlType, ValidationType[]> _map = new()
     {
-        { FormControlType.Text,     new[] { ValidationType.Required, ValidationType.Regex, ValidationType.Email, ValidationType.Number } },
-        { FormControlType.Number,   new[] { ValidationType.Required, ValidationType.Min, ValidationType.Max, ValidationType.Number } },
-        { FormControlType.Date,     new[] { ValidationType.Required, ValidationType.Min, ValidationType.Max } },
-        { FormControlType.Checkbox, new[] { ValidationType.Required } },
-        { FormControlType.Textarea, new[] { ValidationType.Required, ValidationType.Regex, ValidationType.Email, ValidationType.Number } },
-        { FormControlType.Dropdown, new[] { ValidationType.Required } },
+        { FormControlType.Text,     new[] { ValidationType.Regex, ValidationType.Email, ValidationType.Number } },
+        { FormControlType.Number,   new[] { ValidationType.Min, ValidationType.Max, ValidationType.Number } },
+        { FormControlType.Date,     new[] { ValidationType.Min, ValidationType.Max } },
+        { FormControlType.Checkbox, Array.Empty<ValidationType>() },
+        { FormControlType.Textarea, new[] { ValidationType.Regex, ValidationType.Email, ValidationType.Number } },
+        { FormControlType.Dropdown, Array.Empty<ValidationType>() },
     };
 
     public static ValidationType[] GetValidations(FormControlType controlType)
     {
         return _map.TryGetValue(controlType, out var types) ? types : Array.Empty<ValidationType>();
+    }
+
+    public static bool HasValidations(FormControlType controlType)
+    {
+        return _map.TryGetValue(controlType, out var types) && types.Length > 0;
     }
 }

--- a/Views/FormDesigner/_FormFieldSetting.cshtml
+++ b/Views/FormDesigner/_FormFieldSetting.cshtml
@@ -2,10 +2,11 @@
 
 @using ClassLibrary
 @model FormFieldViewModel?
-@{
-    var isDisabled = Model == null;
+@{ 
+    var isDisabled = Model == null; 
     var schemaType = Model?.SchemaType ?? (ViewBag.SchemaType != null ? (TableSchemaQueryType)ViewBag.SchemaType : TableSchemaQueryType.OnlyTable);
     var updateTarget = schemaType == TableSchemaQueryType.OnlyView ? "#formViewFieldList" : "#formFieldList";
+    var showSettingRuleButton = Model != null && ValidationRulesMap.HasValidations(Model.CONTROL_TYPE ?? FormControlType.Text);
 }
 <form id="field-setting-form" asp-action="UpdateFieldSetting" asp-controller="FormDesigner"
       data-ajax="true" data-ajax-method="post" data-ajax-mode="replace" data-ajax-update="@updateTarget">
@@ -85,7 +86,7 @@
             <div class="w-100"></div>
             <div class="col-md-4 d-flex align-items-center">
                 <button type="button"
-                        class="btn btn-outline-primary btn-sm setting-rule-btn"
+                        class="btn btn-outline-primary btn-sm setting-rule-btn @(showSettingRuleButton ? "" : "d-none")"
                         data-id="@Model?.ID"
                         @(Model == null ? "disabled" : "")>
                     設定限制條件


### PR DESCRIPTION
## Summary
- update validation type map to exclude unsupported rule types
- add helper to check if a control type supports validation rules
- hide the setting-rule button when a control has no applicable validations

## Testing
- `dotnet build DynamicForm.sln` *(fails: NETSDK1045 - .NET 9.0 not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688631eed0c483209992513db1af519e