### PR TITLE
強化下拉選項資料結構

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -169,16 +169,16 @@ public class FormDesignerController : Controller
     [HttpPost]
     public IActionResult NewDropdownOption(Guid dropdownId)
     {
-        Guid newId = _formDesignerService.SaveDropdownOption(null, dropdownId, "");
+        Guid newId = _formDesignerService.SaveDropdownOption(null, dropdownId, "", "", "");
         var options = _formDesignerService.GetDropdownOptions(dropdownId);
         return PartialView("Dropdown/_DropdownOptionItem", options);
     }
 
     // 編輯既有選項
     [HttpPost]
-    public IActionResult SaveDropdownOption(Guid id, Guid dropdownId, string optionText)
+    public IActionResult SaveDropdownOption(Guid id, Guid dropdownId, string optionText, string optionValue, string optionTable)
     {
-        _formDesignerService.SaveDropdownOption(id, dropdownId, optionText);
+        _formDesignerService.SaveDropdownOption(id, dropdownId, optionText, optionValue, optionTable);
         return Json(new { success = true });
     }
     

--- a/Models/DropdownSqlSettings.cs
+++ b/Models/DropdownSqlSettings.cs
@@ -1,0 +1,9 @@
+namespace DynamicForm.Models;
+
+public class DropdownSqlSettings
+{
+    /// <summary>
+    /// 用來判斷下拉 SQL 第一欄是否為 ID 的欄位名稱
+    /// </summary>
+    public string IdColumnName { get; set; } = "ID";
+}

--- a/Models/FORM_FIELD_DROPDOWN_OPTIONS.cs
+++ b/Models/FORM_FIELD_DROPDOWN_OPTIONS.cs
@@ -4,7 +4,9 @@ namespace DynamicForm.Models;
 
 public class FORM_FIELD_DROPDOWN_OPTIONS
 {
-    public Guid ID { get; set; }  
-    public Guid FORM_FIELD_DROPDOWN_ID { get; set; }  
-    public string OPTION_TEXT { get; set; }  
+    public Guid ID { get; set; }
+    public Guid FORM_FIELD_DROPDOWN_ID { get; set; }
+    public string OPTION_TABLE { get; set; } = string.Empty;
+    public string OPTION_VALUE { get; set; } = string.Empty;
+    public string OPTION_TEXT { get; set; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,15 @@
 using DynamicForm.Service.Interface;
 using DynamicForm.Service.Service;
+using DynamicForm.Models;
 using Microsoft.Data.SqlClient;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOptions();
+
+// 註冊下拉 SQL 的設定檔
+builder.Services.Configure<DropdownSqlSettings>(builder.Configuration.GetSection("DropdownSql"));
 
 // Service
 builder.Services.AddScoped<IFormListService, FormListService>();

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -35,7 +35,7 @@ public interface IFormDesignerService
     List<FORM_FIELD_DROPDOWN_OPTIONS> GetDropdownOptions(Guid dropDownId);
     
     void SaveDropdownSql(Guid fieldId, string sql);
-    Guid SaveDropdownOption(Guid? id, Guid dropdownId, string optionText);
+    Guid SaveDropdownOption(Guid? id, Guid dropdownId, string optionText, string optionValue, string optionTable);
 
     void DeleteDropdownOption(Guid optionId);
 

--- a/Service/Service/FormService.cs
+++ b/Service/Service/FormService.cs
@@ -113,14 +113,17 @@ public class FormService : IFormService
             {
                 var dict = (IDictionary<string, object>)row;
 
-                // 自動抓第一個欄位作為顯示文字
-                var optionText = dict.Values.FirstOrDefault()?.ToString() ?? "";
+                var values = dict.Values.Take(2).ToArray();
+                var optionValue = values.ElementAtOrDefault(0)?.ToString() ?? string.Empty;
+                var optionText  = values.ElementAtOrDefault(1)?.ToString() ?? string.Empty;
 
                 finalOptions.Add(new FORM_FIELD_DROPDOWN_OPTIONS
                 {
                     ID = Guid.NewGuid(),
                     FORM_FIELD_DROPDOWN_ID = dropdown.ID,
+                    OPTION_VALUE = optionValue,
                     OPTION_TEXT = optionText,
+                    OPTION_TABLE = string.Empty
                 });
             }
         }

--- a/Views/Form/Index.cshtml
+++ b/Views/Form/Index.cshtml
@@ -170,7 +170,8 @@
                                         <option value="">-- 請選擇 --</option>
                                         @foreach (var opt in field.OptionList ?? new())
                                         {
-                                            <option value="@opt.ID">@opt.OPTION_TEXT</option>
+                                            var optionValue = string.IsNullOrEmpty(opt.OPTION_VALUE) ? opt.ID.ToString() : opt.OPTION_VALUE;
+                                            <option value="@optionValue">@opt.OPTION_TEXT</option>
                                         }
                                     </select>
                                 </div>

--- a/Views/FormDesigner/Dropdown/_DropdownOptionItem.cshtml
+++ b/Views/FormDesigner/Dropdown/_DropdownOptionItem.cshtml
@@ -9,9 +9,23 @@
 
             <div class="flex-grow-1">
                 <input type="text"
+                       class="form-control form-control-sm option-value"
+                       value="@opt.OPTION_VALUE"
+                       placeholder="VALUE" />
+            </div>
+
+            <div class="flex-grow-1">
+                <input type="text"
                        class="form-control form-control-sm option-text"
                        value="@opt.OPTION_TEXT"
                        placeholder="請輸入選項文字" />
+            </div>
+
+            <div class="flex-grow-1">
+                <input type="text"
+                       class="form-control form-control-sm option-table"
+                       value="@opt.OPTION_TABLE"
+                       placeholder="OPTION_TABLE" />
             </div>
 
             <button type="button"

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "DropdownSql": {
+    "IdColumnName": "ID"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -10,5 +10,8 @@
     "Connection": "Data Source=127.0.0.1,1433;Initial Catalog=TestDB;User ID=sa;Password=RAIn61490963@;MultipleActiveResultSets=True;TrustServerCertificate=True;"
 
   },
+  "DropdownSql": {
+    "IdColumnName": "ID"
+  },
   "AllowedHosts": "*"
 }

--- a/wwwroot/js/FormDesigner/dropdown/index.js
+++ b/wwwroot/js/FormDesigner/dropdown/index.js
@@ -65,7 +65,7 @@ $(document).on('click', '#addOption', () => {
 });
 
 let timer;
-$(document).on('input', '.option-text', function () {
+$(document).on('input', '.option-text, .option-value, .option-table', function () {
     clearTimeout(timer);
     const $input      = $(this);
     const $li         = $input.closest('li');
@@ -73,13 +73,18 @@ $(document).on('input', '.option-text', function () {
     const dropdownId  = $li.data('dropdown-id');
 
     timer = setTimeout(() => {
-        const optionText = $input.val().trim();
+        const optionText  = $li.find('.option-text').val().trim();
+        const optionValue = $li.find('.option-value').val().trim();
+        const optionTable = $li.find('.option-table').val().trim();
+
         if (!optionText) return;
 
         $.post('/FormDesigner/SaveDropdownOption', {
             id: optionId,
             dropdownId,
-            optionText
+            optionText,
+            optionValue,
+            optionTable
         }).fail(() => {
             console.warn(`✗ ${optionId} 儲存失敗`);
         });


### PR DESCRIPTION
## Summary
- 在 `FORM_FIELD_DROPDOWN_OPTIONS` 模型新增 `OPTION_TABLE` 與 `OPTION_VALUE`
- 下拉選項 UI 增加對應欄位並修改 JS 儲存邏輯
- 服務層改寫 `SaveDropdownOption` 與 SQL 常數，保存 `OPTION_TABLE`
- 動態 SQL 取得選項時同時填入 `OPTION_VALUE`
- 前端表單渲染時使用 `OPTION_VALUE` 作為 option value

## Testing
- `dotnet --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6886d678452c8320a0cd0327e8d9382c