### PR TITLE
Check duplicate table-view pair

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -291,6 +291,12 @@ public class FormDesignerController : Controller
             return BadRequest("VIEW_TABLE_NAME 不可為空");
         }
 
+        // 檢查表格名稱與 View 名稱組合是否重複
+        if (_formDesignerService.CheckFormMasterExists(model.TABLE_NAME, model.VIEW_TABLE_NAME, model.ID))
+        {
+            return Conflict("相同的表格及 View 組合已存在");
+        }
+
         var master = new FORM_FIELD_Master
         {
             ID = model.ID,

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -43,4 +43,13 @@ public interface IFormDesignerService
 
     ValidateSqlResultViewModel ValidateDropdownSql(string sql);
     Guid SaveFormHeader(FORM_FIELD_Master model);
+
+    /// <summary>
+    /// 檢查表格名稱與 View 名稱的組合是否已存在於 FORM_FIELD_Master
+    /// </summary>
+    /// <param name="baseTableName">資料表名稱</param>
+    /// <param name="viewTableName">View 表名稱</param>
+    /// <param name="excludeId">編輯時排除自身 ID</param>
+    /// <returns>若存在相同組合則回傳 true</returns>
+    bool CheckFormMasterExists(string baseTableName, string viewTableName, Guid? excludeId = null);
 }

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -414,6 +414,13 @@ public class FormDesignerService : IFormDesignerService
         return id;
     }
 
+    public bool CheckFormMasterExists(string baseTableName, string viewTableName, Guid? excludeId = null)
+    {
+        var count = _con.ExecuteScalar<int>(Sql.CheckFormMasterExists,
+            new { baseTableName, viewTableName, excludeId });
+        return count > 0;
+    }
+
     public List<FORM_FIELD_Master> GetFormMasters()
     {
         var statusList = new[] { TableStatusType.Active, TableStatusType.Disabled };
@@ -512,6 +519,12 @@ WHEN NOT MATCHED THEN
         @ID, @FORM_NAME, @BASE_TABLE_NAME, @VIEW_TABLE_NAME,
         @PRIMARY_KEY, @BASE_TABLE_ID, @VIEW_TABLE_ID, @STATUS, @SCHEMA_TYPE)
 OUTPUT INSERTED.ID;";
+
+        public const string CheckFormMasterExists = @"/**/
+SELECT COUNT(1) FROM FORM_FIELD_Master
+WHERE BASE_TABLE_NAME = @baseTableName
+  AND VIEW_TABLE_NAME = @viewTableName
+  AND (@excludeId IS NULL OR ID <> @excludeId)";
         
         public const string UpsertField = @"
 MERGE FORM_FIELD_CONFIG AS target


### PR DESCRIPTION
## Summary
- add `CheckFormMasterExists` in service and controller
- use it when saving form header to prevent duplicate BASE_TABLE_NAME and VIEW_TABLE_NAME

## Testing
- `dotnet build` *(fails: NETSDK1045 unsupported .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68870558bc10832085a9c21f452ff6b8