### PR TITLE
Implement SQL import for dropdown options

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -286,6 +286,25 @@ public class FormDesignerController : Controller
     }
 
     /// <summary>
+    /// 執行 SQL 並匯入下拉選單選項
+    /// </summary>
+    /// <param name="dropdownId">目標下拉選單 ID</param>
+    /// <param name="sql">查詢語句</param>
+    /// <param name="optionTable">來源表名稱</param>
+    [HttpPost]
+    public IActionResult ImportOptions(Guid dropdownId, string sql, string optionTable)
+    {
+        var res = _formDesignerService.ImportDropdownOptionsFromSql(sql, dropdownId, optionTable);
+        if (!res.Success)
+        {
+            return BadRequest(res.Message);
+        }
+
+        var options = _formDesignerService.GetDropdownOptions(dropdownId);
+        return PartialView("Dropdown/_DropdownOptionItem", options);
+    }
+
+    /// <summary>
     /// 儲存表單主檔資訊（FormHeader），作為欄位設定的對應關聯。
     /// </summary>
     /// <param name="model">表單主檔 ViewModel</param>

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -42,6 +42,15 @@ public interface IFormDesignerService
     void SetDropdownMode(Guid dropdownId, bool isUseSql);
 
     ValidateSqlResultViewModel ValidateDropdownSql(string sql);
+
+    /// <summary>
+    /// 執行 SQL 並將結果匯入指定的下拉選單選項表
+    /// </summary>
+    /// <param name="sql">要執行的查詢語法（僅限 SELECT）</param>
+    /// <param name="dropdownId">目標下拉選單 ID</param>
+    /// <param name="optionTable">來源資料表名稱</param>
+    /// <returns>SQL 驗證與匯入結果</returns>
+    ValidateSqlResultViewModel ImportDropdownOptionsFromSql(string sql, Guid dropdownId, string optionTable);
     Guid SaveFormHeader(FORM_FIELD_Master model);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add ImportDropdownOptionsFromSql to the form designer service and interface
- expose new controller action `ImportOptions`
- store dropdown options from SQL results while avoiding duplicates

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882b8708f88320b635a6eb5ae66179