### PR TITLE
Implement SQL import for dropdown options

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -286,6 +286,25 @@ public class FormDesignerController : Controller
     }
 
     /// <summary>
+    /// 執行 SQL 並匯入下拉選單選項
+    /// </summary>
+    /// <param name="dropdownId">目標下拉選單 ID</param>
+    /// <param name="sql">查詢語句</param>
+    /// <param name="optionTable">來源表名稱</param>
+    [HttpPost]
+    public IActionResult ImportOptions(Guid dropdownId, string sql, string optionTable)
+    {
+        var res = _formDesignerService.ImportDropdownOptionsFromSql(sql, dropdownId, optionTable);
+        if (!res.Success)
+        {
+            return BadRequest(res.Message);
+        }
+
+        var options = _formDesignerService.GetDropdownOptions(dropdownId);
+        return PartialView("Dropdown/_DropdownOptionItem", options);
+    }
+
+    /// <summary>
     /// 儲存表單主檔資訊（FormHeader），作為欄位設定的對應關聯。
     /// </summary>
     /// <param name="model">表單主檔 ViewModel</param>

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -42,6 +42,15 @@ public interface IFormDesignerService
     void SetDropdownMode(Guid dropdownId, bool isUseSql);
 
     ValidateSqlResultViewModel ValidateDropdownSql(string sql);
+
+    /// <summary>
+    /// 執行 SQL 並將結果匯入指定的下拉選單選項表
+    /// </summary>
+    /// <param name="sql">要執行的查詢語法（僅限 SELECT）</param>
+    /// <param name="dropdownId">目標下拉選單 ID</param>
+    /// <param name="optionTable">來源資料表名稱</param>
+    /// <returns>SQL 驗證與匯入結果</returns>
+    ValidateSqlResultViewModel ImportDropdownOptionsFromSql(string sql, Guid dropdownId, string optionTable);
     Guid SaveFormHeader(FORM_FIELD_Master model);
 
     /// <summary>

--- a/Views/FormDesigner/Dropdown/_ValidateSqlResult.cshtml
+++ b/Views/FormDesigner/Dropdown/_ValidateSqlResult.cshtml
@@ -32,6 +32,17 @@
             </table>
         </div>
     }
+
+    <div class="mt-2 d-flex align-items-end gap-2">
+        <input type="text"
+               class="form-control form-control-sm"
+               id="importOptionTable"
+               placeholder="來源表名稱 (OPTION_TABLE)" />
+
+        <button type="button" class="btn btn-sm btn-primary" id="importOptionsBtn">
+            <i class="bi bi-download"></i> 匯入選項
+        </button>
+    </div>
 }
 else
 {

--- a/wwwroot/js/FormDesigner/dropdown/index.js
+++ b/wwwroot/js/FormDesigner/dropdown/index.js
@@ -116,3 +116,16 @@ $(document).on('click', '#validateSqlBtn', function () {
         .fail(function () {
         });
 });
+
+$(document).on('click', '#importOptionsBtn', function () {
+    const dropdownId  = $('#dropdownModal').data('dropdown-id');
+    const sql         = $('#dropdownSql').val()?.trim();
+    const optionTable = $('#importOptionTable').val()?.trim();
+
+    if (!dropdownId || !sql) return;
+
+    $.post('/FormDesigner/ImportOptions',
+        { dropdownId, sql, optionTable })
+        .done(html => $('#optionList').html(html))
+        .fail(xhr => alert(xhr.responseText || '匯入失敗'));
+});


### PR DESCRIPTION
## Summary
- add ImportOptions button after validating SQL results
- send ImportOptions request from dropdown UI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882b8708f88320b635a6eb5ae66179