### PR TITLE
Fix required flag for non-editable fields

### DIFF
--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -190,6 +190,9 @@ public class FormDesignerService : IFormDesignerService
     {
         var controlType = model.CONTROL_TYPE ?? FormFieldHelper.GetDefaultControlType(model.DATA_TYPE);
 
+        // 只有在欄位可編輯時才允許設定必填
+        var isRequired = model.IS_EDITABLE && model.IS_REQUIRED;
+
         var param = new
         {
             ID = model.ID == Guid.Empty ? Guid.NewGuid() : model.ID,
@@ -198,7 +201,7 @@ public class FormDesignerService : IFormDesignerService
             model.COLUMN_NAME,
             model.DATA_TYPE,
             CONTROL_TYPE = controlType,
-            model.IS_REQUIRED,
+            IS_REQUIRED = isRequired,
             model.IS_VISIBLE,
             model.IS_EDITABLE,
             model.DEFAULT_VALUE

--- a/Views/FormDesigner/_FormFieldSetting.cshtml
+++ b/Views/FormDesigner/_FormFieldSetting.cshtml
@@ -53,8 +53,9 @@
             @*     </div> *@
             @* </div> *@
             <div class="col-md-4 d-flex align-items-center">
+                @* 不可編輯時，必填也應禁用 *@
                 <div class="form-check">
-                    <input type="checkbox" asp-for="IS_REQUIRED" class="form-check-input" id="isRequiredCheck" />
+                    <input type="checkbox" asp-for="IS_REQUIRED" class="form-check-input" id="isRequiredCheck" disabled="@(!Model?.IS_EDITABLE ?? false)" />
                     <label class="form-check-label" for="isRequiredCheck">必填</label>
                 </div>
             </div>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -84,6 +84,7 @@ function loadFieldSetting(tableName, columnName, schemaType) {
         success: function (html) {
             $('#formFieldSetting').html(html);
             toggleDropdownButton();
+            syncEditableRequired();
         },
         error: function () {
             alert('載入欄位設定失敗');
@@ -100,7 +101,21 @@ function toggleDropdownButton() {
     }
 }
 
+// 當欄位不可編輯時，必填選項應一併取消並禁用
+function syncEditableRequired() {
+    const $editable = $('#editableCheck');
+    const $required = $('#isRequiredCheck');
+    if ($editable.length === 0 || $required.length === 0) return;
+
+    if (!$editable.prop('checked')) {
+        $required.prop('checked', false).prop('disabled', true);
+    } else {
+        $required.prop('disabled', false);
+    }
+}
+
 $(document).on('change', '#CONTROL_TYPE', toggleDropdownButton);
+$(document).on('change', '#editableCheck', syncEditableRequired);
 
 /*
 * 更新設定


### PR DESCRIPTION
## Summary
- auto-disable required flag when field is set non-editable in Form Designer
- prevent saving required=true when editable=false
- disable Required checkbox in field settings when editing disabled

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688b1e00ab088320ac91038f1d81f90a