### PR TITLE
validate schema before saving form master

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -4,6 +4,7 @@ using DynamicForm.Service.Interface;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Collections.Generic;
+using System;
 
 namespace DynamicForm.Controllers;
 
@@ -302,9 +303,16 @@ public class FormDesignerController : Controller
             SCHEMA_TYPE = TableSchemaQueryType.All
         };
 
-        var id = _formDesignerService.SaveFormHeader(master);
-
-        return Json(new { success = true, id });
+        try
+        {
+            var id = _formDesignerService.SaveFormHeader(master);
+            return Json(new { success = true, id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            // 主表或顯示用 View 查詢失敗時回傳錯誤訊息
+            return BadRequest(ex.Message);
+        }
     }
     
     /// <summary>

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -6,6 +6,7 @@ using DynamicForm.Helper;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System;
 using DynamicForm.Service.Interface.FormLogicInterface;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Options;
@@ -501,7 +502,14 @@ public class FormDesignerService : IFormDesignerService
 
     public Guid SaveFormHeader(FORM_FIELD_Master model)
     {
-        // 若不存在則產生新 ID
+        // 確保主表與顯示用 View 皆能成功查詢，避免儲存無效設定
+        if (GetTableSchema(model.BASE_TABLE_NAME, TableSchemaQueryType.OnlyTable).Count == 0)
+            throw new InvalidOperationException("主表名稱查無資料");
+
+        if (GetTableSchema(model.VIEW_TABLE_NAME, TableSchemaQueryType.OnlyView).Count == 0)
+            throw new InvalidOperationException("顯示用 View 名稱查無資料");
+
+        // 若未指定 ID 則產生新 ID
         if (model.ID == Guid.Empty)
         {
             model.ID = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- ensure main table and display view exist before saving form configuration
- return clear error message when schema lookup fails

## Testing
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688b2d82b5a88320b137b2db126074db