### PR TITLE
feat: add bulk edit controls

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -89,6 +89,52 @@ public class FormDesignerController : Controller
     }
 
     /// <summary>
+    /// 批次更新指定清單所有欄位的可編輯狀態。
+    /// 目前僅支援 SCHEMA_TYPE 為 OnlyView (1) 的欄位清單。
+    /// </summary>
+    /// <param name="formMasterId">FORM_FIELD_Master ID</param>
+    /// <param name="tableName">欄位所屬資料表名稱</param>
+    /// <param name="isEditable">更新後的可編輯狀態</param>
+    /// <param name="schemaType">查詢類型</param>
+    [HttpPost]
+    public IActionResult SetAllEditable(Guid formMasterId, string tableName, bool isEditable, TableSchemaQueryType schemaType)
+    {
+        if (schemaType != TableSchemaQueryType.OnlyView)
+        {
+            return BadRequest("僅支援檢視欄位清單的批次設定。");
+        }
+
+        _formDesignerService.SetAllEditable(formMasterId, tableName, isEditable);
+        var fields = _formDesignerService.GetFieldsByTableName(tableName, schemaType);
+        fields.ID = formMasterId;
+        fields.type = schemaType;
+        return PartialView("_FormFieldList", fields);
+    }
+
+    /// <summary>
+    /// 批次更新指定清單所有欄位的必填狀態。
+    /// 目前僅支援 SCHEMA_TYPE 為 OnlyView (1) 的欄位清單。
+    /// </summary>
+    /// <param name="formMasterId">FORM_FIELD_Master ID</param>
+    /// <param name="tableName">欄位所屬資料表名稱</param>
+    /// <param name="isRequired">更新後的必填狀態</param>
+    /// <param name="schemaType">查詢類型</param>
+    [HttpPost]
+    public IActionResult SetAllRequired(Guid formMasterId, string tableName, bool isRequired, TableSchemaQueryType schemaType)
+    {
+        if (schemaType != TableSchemaQueryType.OnlyView)
+        {
+            return BadRequest("僅支援檢視欄位清單的批次設定。");
+        }
+
+        _formDesignerService.SetAllRequired(formMasterId, tableName, isRequired);
+        var fields = _formDesignerService.GetFieldsByTableName(tableName, schemaType);
+        fields.ID = formMasterId;
+        fields.type = schemaType;
+        return PartialView("_FormFieldList", fields);
+    }
+
+    /// <summary>
     /// 檢查指定欄位 ID 是否存在於資料庫中(要先有控制元件，才能新增限制條件)
     /// </summary>
     /// <param name="fieldId">欄位唯一識別碼</param>

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -12,6 +12,16 @@ public interface IFormDesignerService
 
     void UpsertField(FormFieldViewModel model, Guid formMasterId);
 
+    /// <summary>
+    /// 批次設定欄位的可編輯狀態。
+    /// </summary>
+    void SetAllEditable(Guid formMasterId, string tableName, bool isEditable);
+
+    /// <summary>
+    /// 批次設定欄位的必填狀態。
+    /// </summary>
+    void SetAllRequired(Guid formMasterId, string tableName, bool isRequired);
+
     bool CheckFieldExists(Guid fieldId);
     
     List<FormFieldValidationRuleDto> GetValidationRulesByFieldId(Guid fieldId);

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -222,6 +222,23 @@ public class FormDesignerService : IFormDesignerService
     }
 
     /// <summary>
+    /// 批次設定欄位的可編輯狀態。
+    /// 若設定為不可編輯，會同步取消必填。
+    /// </summary>
+    public void SetAllEditable(Guid formMasterId, string tableName, bool isEditable)
+    {
+        _con.Execute(Sql.SetAllEditable, new { formMasterId, tableName, isEditable });
+    }
+
+    /// <summary>
+    /// 批次設定欄位的必填狀態，僅對可編輯欄位生效。
+    /// </summary>
+    public void SetAllRequired(Guid formMasterId, string tableName, bool isRequired)
+    {
+        _con.Execute(Sql.SetAllRequired, new { formMasterId, tableName, isRequired });
+    }
+
+    /// <summary>
     /// 檢查指定 FORM_FIELD_CONFIG ID 是否已存在於設定資料表中。
     /// </summary>
     /// <param name="fieldId">欄位唯一識別碼</param>
@@ -677,6 +694,17 @@ WHEN NOT MATCHED THEN
 
         public const string CheckFieldExists         = @"/**/
 SELECT COUNT(1) FROM FORM_FIELD_CONFIG WHERE ID = @fieldId";
+
+        public const string SetAllEditable = @"/**/
+UPDATE FORM_FIELD_CONFIG
+SET IS_EDITABLE = @isEditable,
+    IS_REQUIRED = CASE WHEN @isEditable = 0 THEN 0 ELSE IS_REQUIRED END
+WHERE FORM_FIELD_Master_ID = @formMasterId AND TABLE_NAME = @tableName";
+
+        public const string SetAllRequired = @"/**/
+UPDATE FORM_FIELD_CONFIG
+SET IS_REQUIRED = CASE WHEN @isRequired = 1 AND IS_EDITABLE = 1 THEN 1 ELSE 0 END
+WHERE FORM_FIELD_Master_ID = @formMasterId AND TABLE_NAME = @tableName";
         
         public const string CountValidationRules     = @"/**/
 SELECT COUNT(1) FROM FORM_FIELD_VALIDATION_RULE WHERE FIELD_CONFIG_ID = @fieldId";

--- a/Views/FormDesigner/_FormFieldList.cshtml
+++ b/Views/FormDesigner/_FormFieldList.cshtml
@@ -3,13 +3,42 @@
 @using ClassLibrary
 @model FormFieldListViewModel?
 
-<div style="max-height: 400px; overflow-y: auto;" data-master-id="@Model?.ID">
-    <table class="table table-bordered table-striped table-hover align-middle text-sm w-100" style="table-layout: fixed;">
-        <thead class="table-light" style="position: sticky; top: 0; z-index: 5;">
-        <tr>
-            <th style="min-width: 150px;">欄位名稱</th>
-            <th style="min-width: 100px;">型別</th>
-            <th style="min-width: 150px;">控制元件</th>
+@{
+    // 判斷所有欄位目前是否為可編輯或必填，用於決定按鈕文字與下一個狀態
+    var allEditable = Model?.Fields?.All(f => f.IS_EDITABLE) ?? false;
+    var allRequired = Model?.Fields?.All(f => f.IS_REQUIRED) ?? false;
+}
+
+<div class="field-list-container"
+     data-master-id="@Model?.ID"
+     data-table-name="@Model?.TableName"
+     data-schema-type="@((int?)Model?.type)">
+    @* 只有 SchemaType 為 OnlyView (1) 時顯示批次設定按鈕 *@
+    @if (Model?.type == TableSchemaQueryType.OnlyView)
+    {
+        <div class="d-flex justify-content-end mb-2">
+            <button type="button"
+                    class="btn btn-sm btn-outline-primary me-2"
+                    data-editable="@((!allEditable).ToString().ToLower())"
+                    onclick="toggleAllEditable(this)">
+                @(allEditable ? "全部設為不可編輯" : "全部設為可編輯")
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-primary"
+                    data-required="@((!allRequired).ToString().ToLower())"
+                    onclick="toggleAllRequired(this)">
+                @(allRequired ? "全部不用必填" : "全部設為必填")
+            </button>
+        </div>
+    }
+
+    <div style="max-height: 400px; overflow-y: auto;">
+        <table class="table table-bordered table-striped table-hover align-middle text-sm w-100" style="table-layout: fixed;">
+            <thead class="table-light" style="position: sticky; top: 0; z-index: 5;">
+            <tr>
+                <th style="min-width: 150px;">欄位名稱</th>
+                <th style="min-width: 100px;">型別</th>
+                <th style="min-width: 150px;">控制元件</th>
             @* <th style="min-width: 60px;">顯示</th> *@
             <th style="min-width: 60px;">必填</th>
             <th style="min-width: 60px;">編輯</th>
@@ -41,4 +70,5 @@
         }
         </tbody>
     </table>
+    </div>
 </div>

--- a/wwwroot/js/FormDesigner/index.js
+++ b/wwwroot/js/FormDesigner/index.js
@@ -279,3 +279,48 @@ $(document).on('click', '.delete-rule', function () {
 $(document).on('click', '.closeModal', function () {
     $(this).closest('.modal').modal('hide');
 });
+
+/*
+ * 批次設定欄位的可編輯與必填
+ */
+function toggleAllEditable(btn) {
+    const $btn = $(btn);
+    const targetEditable = $btn.data('editable');
+    const $container = $btn.closest('.field-list-container');
+    const formMasterId = $container.data('master-id');
+    const tableName = $container.data('table-name');
+    const schemaType = $container.data('schema-type');
+
+    $.ajax({
+        url: '/FormDesigner/SetAllEditable',
+        type: 'POST',
+        data: { formMasterId, tableName, isEditable: targetEditable, schemaType },
+        success: function (html) {
+            $container.replaceWith(html);
+        },
+        error: function () {
+            alert('批次更新可編輯狀態失敗');
+        }
+    });
+}
+
+function toggleAllRequired(btn) {
+    const $btn = $(btn);
+    const targetRequired = $btn.data('required');
+    const $container = $btn.closest('.field-list-container');
+    const formMasterId = $container.data('master-id');
+    const tableName = $container.data('table-name');
+    const schemaType = $container.data('schema-type');
+
+    $.ajax({
+        url: '/FormDesigner/SetAllRequired',
+        type: 'POST',
+        data: { formMasterId, tableName, isRequired: targetRequired, schemaType },
+        success: function (html) {
+            $container.replaceWith(html);
+        },
+        error: function () {
+            alert('批次更新必填狀態失敗');
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- add bulk actions to set field editability and required flags for view schema
- expose service APIs and SQL to update all field config records
- wire up client-side buttons and Ajax handlers

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688b2dcf41488320bcddd88af0a981f8