### PR TITLE
Add unit tests for type conversion helpers

### DIFF
--- a/DynamicForm.Tests/ConvertToColumnTypeHelperTests.cs
+++ b/DynamicForm.Tests/ConvertToColumnTypeHelperTests.cs
@@ -1,0 +1,49 @@
+using System;
+using DynamicForm.Helper;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class ConvertToColumnTypeHelperTests
+{
+    [Fact]
+    public void Convert_Int_ReturnsLong()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("int", "123");
+        var value = Assert.IsType<long>(result);
+        Assert.Equal(123L, value);
+    }
+
+    [Fact]
+    public void Convert_Decimal_ReturnsDecimal()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("decimal", "123.45");
+        var value = Assert.IsType<decimal>(result);
+        Assert.Equal(123.45m, value);
+    }
+
+    [Fact]
+    public void Convert_Datetime_ReturnsDateTime()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("datetime", "2024-01-01");
+        var value = Assert.IsType<DateTime>(result);
+        Assert.Equal(new DateTime(2024, 1, 1), value);
+    }
+
+    [Fact]
+    public void Convert_Bool_ReturnsBoolean()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("bit", "1");
+        var value = Assert.IsType<bool>(result);
+        Assert.True(value);
+    }
+
+    [Fact]
+    public void Convert_Nvarchar_ReturnsString()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("nvarchar", "hello");
+        var value = Assert.IsType<string>(result);
+        Assert.Equal("hello", value);
+    }
+}
+

--- a/DynamicForm.Tests/DynamicForm.Tests.csproj
+++ b/DynamicForm.Tests/DynamicForm.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DynamicForm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DynamicForm.Tests/PkHelperTests.cs
+++ b/DynamicForm.Tests/PkHelperTests.cs
@@ -1,0 +1,70 @@
+using System;
+using DynamicForm.Helper;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class PkHelperTests
+{
+    [Fact]
+    public void ConvertPkType_Guid_ReturnsGuid()
+    {
+        var guid = Guid.NewGuid();
+        var result = ConvertToColumnTypeHelper.ConvertPkType(guid.ToString(), "uniqueidentifier");
+        var value = Assert.IsType<Guid>(result);
+        Assert.Equal(guid, value);
+    }
+
+    [Fact]
+    public void ConvertPkType_Int_ReturnsInt()
+    {
+        var result = ConvertToColumnTypeHelper.ConvertPkType("123", "int");
+        var value = Assert.IsType<int>(result);
+        Assert.Equal(123, value);
+    }
+
+    [Fact]
+    public void ConvertPkType_String_ReturnsString()
+    {
+        var result = ConvertToColumnTypeHelper.ConvertPkType("abc", "nvarchar");
+        var value = Assert.IsType<string>(result);
+        Assert.Equal("abc", value);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Uniqueidentifier_ReturnsGuid()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("uniqueidentifier");
+        Assert.IsType<Guid>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Numeric_ReturnsDecimal()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("numeric");
+        Assert.IsType<decimal>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Bigint_ReturnsLong()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("bigint");
+        Assert.IsType<long>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Int_ReturnsInt()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("int");
+        Assert.IsType<int>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Nvarchar_ReturnsString()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("nvarchar");
+        var value = Assert.IsType<string>(result);
+        Assert.False(string.IsNullOrWhiteSpace(value));
+    }
+}
+

--- a/DynamicForm.csproj
+++ b/DynamicForm.csproj
@@ -12,11 +12,15 @@
       <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.64.0" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <_ContentIncludedByDefault Remove="Views\FormBuilder\Edit.cshtml" />
       <_ContentIncludedByDefault Remove="Views\FormBuilder\FieldEdit.cshtml" />
       <_ContentIncludedByDefault Remove="Views\FormBuilder\index.cshtml" />
-    </ItemGroup>
+      <!-- Exclude test project files from main project compilation -->
+      <Compile Remove="DynamicForm.Tests\**" />
+      <EmbeddedResource Remove="DynamicForm.Tests\**" />
+      <None Remove="DynamicForm.Tests\**" />
+  </ItemGroup>
 
     <ItemGroup>
       <Folder Include="Models\" />

--- a/DynamicForm.sln
+++ b/DynamicForm.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicForm", "DynamicForm.csproj", "{7711266C-0080-4A91-B47E-DA28FEDAB1B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicForm.Tests", "DynamicForm.Tests\DynamicForm.Tests.csproj", "{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x64.Build.0 = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x86.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x64.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xUnit test project
- cover Convert, ConvertPkType, and GeneratePkValue behavior
- exclude test files from main project compilation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688c2996b2748320b478ddf0b8734822