### PR TITLE
Add unit tests for helper utilities

### DIFF
--- a/DynamicForm.Tests/ConvertToColumnTypeHelperTests.cs
+++ b/DynamicForm.Tests/ConvertToColumnTypeHelperTests.cs
@@ -1,0 +1,49 @@
+using System;
+using DynamicForm.Helper;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class ConvertToColumnTypeHelperTests
+{
+    [Fact]
+    public void Convert_Int_ReturnsLong()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("int", "123");
+        var value = Assert.IsType<long>(result);
+        Assert.Equal(123L, value);
+    }
+
+    [Fact]
+    public void Convert_Decimal_ReturnsDecimal()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("decimal", "123.45");
+        var value = Assert.IsType<decimal>(result);
+        Assert.Equal(123.45m, value);
+    }
+
+    [Fact]
+    public void Convert_Datetime_ReturnsDateTime()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("datetime", "2024-01-01");
+        var value = Assert.IsType<DateTime>(result);
+        Assert.Equal(new DateTime(2024, 1, 1), value);
+    }
+
+    [Fact]
+    public void Convert_Bool_ReturnsBoolean()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("bit", "1");
+        var value = Assert.IsType<bool>(result);
+        Assert.True(value);
+    }
+
+    [Fact]
+    public void Convert_Nvarchar_ReturnsString()
+    {
+        var result = ConvertToColumnTypeHelper.Convert("nvarchar", "hello");
+        var value = Assert.IsType<string>(result);
+        Assert.Equal("hello", value);
+    }
+}
+

--- a/DynamicForm.Tests/DropdownServiceTests.cs
+++ b/DynamicForm.Tests/DropdownServiceTests.cs
@@ -1,0 +1,52 @@
+using DynamicForm.Models;
+using DynamicForm.Service.Service.FormLogicService;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class DropdownServiceTests
+{
+    [Fact]
+    public void ToFormDataRows_MapsCellsAndIdsCorrectly()
+    {
+        // Arrange: 模擬資料列，包含主鍵與其他欄位
+        var rawRows = new List<IDictionary<string, object?>>
+        {
+            new Dictionary<string, object?> { { "Id", 1 }, { "Name", "Alice" } },
+            new Dictionary<string, object?> { { "Id", 2 }, { "Name", "Bob" } }
+        };
+        var service = new DropdownService(new SqlConnection());
+
+        // Act: 轉換成 ViewModel 並收集主鍵
+        var rows = service.ToFormDataRows(rawRows, "Id", out var rowIds);
+
+        // Assert: 驗證資料列數量、主鍵集合與欄位內容
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new object[] { 1, 2 }, rowIds);
+
+        var firstRow = rows[0];
+        Assert.Equal(1, firstRow.Id);
+        Assert.Contains(firstRow.Cells, c => c.ColumnName == "Id" && (int)c.Value! == 1);
+        Assert.Contains(firstRow.Cells, c => c.ColumnName == "Name" && (string)c.Value! == "Alice");
+    }
+
+    [Fact]
+    public void ToFormDataRows_RespectsPkColumnCaseInsensitively()
+    {
+        // Arrange: 主鍵欄位名稱大小寫不一致也應被辨識
+        var rawRows = new List<IDictionary<string, object?>>
+        {
+            new Dictionary<string, object?> { { "id", 99 }, { "Name", "Charlie" } }
+        };
+        var service = new DropdownService(new SqlConnection());
+
+        // Act
+        var rows = service.ToFormDataRows(rawRows, "ID", out var rowIds);
+
+        // Assert
+        Assert.Single(rows);
+        Assert.Single(rowIds);
+        Assert.Equal(99, rows[0].Id);
+    }
+}

--- a/DynamicForm.Tests/DynamicForm.Tests.csproj
+++ b/DynamicForm.Tests/DynamicForm.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DynamicForm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DynamicForm.Tests/PkHelperTests.cs
+++ b/DynamicForm.Tests/PkHelperTests.cs
@@ -1,0 +1,70 @@
+using System;
+using DynamicForm.Helper;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class PkHelperTests
+{
+    [Fact]
+    public void ConvertPkType_Guid_ReturnsGuid()
+    {
+        var guid = Guid.NewGuid();
+        var result = ConvertToColumnTypeHelper.ConvertPkType(guid.ToString(), "uniqueidentifier");
+        var value = Assert.IsType<Guid>(result);
+        Assert.Equal(guid, value);
+    }
+
+    [Fact]
+    public void ConvertPkType_Int_ReturnsInt()
+    {
+        var result = ConvertToColumnTypeHelper.ConvertPkType("123", "int");
+        var value = Assert.IsType<int>(result);
+        Assert.Equal(123, value);
+    }
+
+    [Fact]
+    public void ConvertPkType_String_ReturnsString()
+    {
+        var result = ConvertToColumnTypeHelper.ConvertPkType("abc", "nvarchar");
+        var value = Assert.IsType<string>(result);
+        Assert.Equal("abc", value);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Uniqueidentifier_ReturnsGuid()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("uniqueidentifier");
+        Assert.IsType<Guid>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Numeric_ReturnsDecimal()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("numeric");
+        Assert.IsType<decimal>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Bigint_ReturnsLong()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("bigint");
+        Assert.IsType<long>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Int_ReturnsInt()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("int");
+        Assert.IsType<int>(result);
+    }
+
+    [Fact]
+    public void GeneratePkValue_Nvarchar_ReturnsString()
+    {
+        var result = GeneratePkValueHelper.GeneratePkValue("nvarchar");
+        var value = Assert.IsType<string>(result);
+        Assert.False(string.IsNullOrWhiteSpace(value));
+    }
+}
+

--- a/DynamicForm.Tests/RandomHelperTests.cs
+++ b/DynamicForm.Tests/RandomHelperTests.cs
@@ -1,0 +1,24 @@
+using DynamicForm.Helper;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class RandomHelperTests
+{
+    [Fact]
+    public void GenerateRandomDecimal_ReturnsNonNegativeValueWithinRange()
+    {
+        var value = RandomHelper.GenerateRandomDecimal();
+        Assert.True(value >= 0m && value <= 999_999_999_999_999_999m);
+    }
+
+    [Fact]
+    public void NextSnowflakeId_ReturnsUniquePositiveIds()
+    {
+        var id1 = RandomHelper.NextSnowflakeId();
+        var id2 = RandomHelper.NextSnowflakeId();
+        Assert.True(id1 > 0);
+        Assert.True(id2 > 0);
+        Assert.NotEqual(id1, id2);
+    }
+}

--- a/DynamicForm.Tests/ValidationRulesMapTests.cs
+++ b/DynamicForm.Tests/ValidationRulesMapTests.cs
@@ -1,0 +1,47 @@
+using ClassLibrary;
+using Xunit;
+
+namespace DynamicForm.Tests;
+
+public class ValidationRulesMapTests
+{
+    [Fact]
+    public void GetValidations_Text_ReturnsRegex()
+    {
+        var result = ValidationRulesMap.GetValidations(FormControlType.Text);
+        Assert.Equal(new[] { ValidationType.Regex }, result);
+    }
+
+    [Fact]
+    public void GetValidations_Number_ReturnsMinAndMax()
+    {
+        var result = ValidationRulesMap.GetValidations(FormControlType.Number);
+        Assert.Equal(new[] { ValidationType.Min, ValidationType.Max }, result);
+    }
+
+    [Fact]
+    public void GetValidations_Checkbox_ReturnsEmpty()
+    {
+        var result = ValidationRulesMap.GetValidations(FormControlType.Checkbox);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void HasValidations_Text_ReturnsTrue()
+    {
+        Assert.True(ValidationRulesMap.HasValidations(FormControlType.Text));
+    }
+
+    [Fact]
+    public void HasValidations_Dropdown_ReturnsFalse()
+    {
+        Assert.False(ValidationRulesMap.HasValidations(FormControlType.Dropdown));
+    }
+
+    [Fact]
+    public void GetValidations_Unknown_ReturnsEmpty()
+    {
+        var result = ValidationRulesMap.GetValidations((FormControlType)999);
+        Assert.Empty(result);
+    }
+}

--- a/DynamicForm.csproj
+++ b/DynamicForm.csproj
@@ -12,11 +12,15 @@
       <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.64.0" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <_ContentIncludedByDefault Remove="Views\FormBuilder\Edit.cshtml" />
       <_ContentIncludedByDefault Remove="Views\FormBuilder\FieldEdit.cshtml" />
       <_ContentIncludedByDefault Remove="Views\FormBuilder\index.cshtml" />
-    </ItemGroup>
+      <!-- Exclude test project files from main project compilation -->
+      <Compile Remove="DynamicForm.Tests\**" />
+      <EmbeddedResource Remove="DynamicForm.Tests\**" />
+      <None Remove="DynamicForm.Tests\**" />
+  </ItemGroup>
 
     <ItemGroup>
       <Folder Include="Models\" />

--- a/DynamicForm.sln
+++ b/DynamicForm.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicForm", "DynamicForm.csproj", "{7711266C-0080-4A91-B47E-DA28FEDAB1B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicForm.Tests", "DynamicForm.Tests\DynamicForm.Tests.csproj", "{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x64.Build.0 = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{7711266C-0080-4A91-B47E-DA28FEDAB1B2}.Release|x86.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x64.Build.0 = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5E9FC86-1414-41E8-A1C6-28A10BE5F139}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add tests for ValidationRulesMap to verify rule lookup and validation presence
- add tests for RandomHelper to ensure random decimal range and snowflake uniqueness
- add tests for DropdownService.ToFormDataRows to confirm row mapping and primary key extraction

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688c2996b2748320b478ddf0b8734822