### PR TITLE
feat: ensure required system columns exist

### DIFF
--- a/Helper/HttpStatusCodeException.cs
+++ b/Helper/HttpStatusCodeException.cs
@@ -1,0 +1,23 @@
+using System.Net;
+
+namespace DynamicForm.Helper;
+
+/// <summary>
+/// Represents an HTTP error with an associated status code.
+/// </summary>
+public class HttpStatusCodeException : Exception
+{
+    /// <summary>
+    /// The HTTP status code to return to the client.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Create a new exception with a specific HTTP status code and message.
+    /// </summary>
+    public HttpStatusCodeException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "DropdownSql": {
     "IdColumnName": "ID"
+  },
+  "FormDesignerSettings": {
+    "RequiredColumns": [ "CREATE_USER", "CREATE_TIME", "EDIT_USER", "EDIT_TIME" ]
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,12 +6,13 @@
     }
   },
   "ConnectionStrings": {
-    "Connection": "Data Source=localhost;Initial Catalog=TestDB;User ID=sa;Password=RAIN61490963;MultipleActiveResultSets=True;TrustServerCertificate=True;",
-    //////"Connection": "Data Source=127.0.0.1,1433;Initial Catalog=TestDB;User ID=sa;Password=RAIn61490963@;MultipleActiveResultSets=True;TrustServerCertificate=True;"
-
+    "Connection": "Data Source=localhost;Initial Catalog=TestDB;User ID=sa;Password=RAIN61490963;MultipleActiveResultSets=True;TrustServerCertificate=True;"
   },
   "DropdownSqlSettings": {
     "ExcludeColumns": [ "ID", "SID" ]
+  },
+  "FormDesignerSettings": {
+    "RequiredColumns": [ "CREATE_USER", "CREATE_TIME", "EDIT_USER", "EDIT_TIME" ]
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- validate presence of CREATE_USER/CREATE_TIME/EDIT_USER/EDIT_TIME before field operations
- propagate validation errors to API consumers
- add controller unit tests for missing system columns
- load required system column names from configuration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68906be1df2c83208dab906b612bd3ee