### PR TITLE
Return multiple forms from GetForms

### DIFF
--- a/DynamicForm.Tests/ApiControllerTest/FormControllerTests.cs
+++ b/DynamicForm.Tests/ApiControllerTest/FormControllerTests.cs
@@ -3,6 +3,7 @@ using DynamicForm.Service.Interface;
 using DynamicForm.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using System.Collections.Generic;
 
 namespace DynamicForm.Tests.ApiControllerTest;
 
@@ -24,7 +25,7 @@ public class FormControllerTests
     [Fact]
     public void GetForms_ReturnsOkWithViewModel()
     {
-        var vm = new FormListDataViewModel { FormMasterId = Guid.NewGuid() };
+        var vm = new List<FormListDataViewModel> { new FormListDataViewModel { FormMasterId = Guid.NewGuid() } };
         _serviceMock.Setup(s => s.GetFormList()).Returns(vm);
 
         var result = _controller.GetForms() as OkObjectResult;

--- a/Service/Interface/FormLogicInterface/IFormFieldMasterService.cs
+++ b/Service/Interface/FormLogicInterface/IFormFieldMasterService.cs
@@ -1,6 +1,8 @@
 ﻿using DynamicForm.Models;
+using DynamicForm.ViewModels;
 using ClassLibrary;
 using Microsoft.Data.SqlClient;
+using System.Collections.Generic;
 
 namespace DynamicForm.Service.Interface.FormLogicInterface;
 
@@ -10,6 +12,6 @@ public interface IFormFieldMasterService
 
     FORM_FIELD_Master GetFormFieldMasterFromId(Guid id, SqlTransaction? tx = null );
 
-    (FORM_FIELD_Master Master, List<string> SchemaColumns, List<FormFieldConfigDto> FieldConfigs) GetFormMetaAggregate(
+    List<(FORM_FIELD_Master Master, List<FormFieldInputViewModel> FieldConfigRows)> GetFormMetaAggregates(
         TableSchemaQueryType type);
 }

--- a/Service/Interface/IFormService.cs
+++ b/Service/Interface/IFormService.cs
@@ -1,13 +1,15 @@
 ﻿using DynamicForm.ViewModels;
+using System.Collections.Generic;
 
 namespace DynamicForm.Service.Interface;
 
 public interface IFormService
 {
     /// <summary>
-    /// 取得 列表
+    /// 取得所有表單的資料列表。
     /// </summary>
-    FormListDataViewModel GetFormList();
+    /// <returns>每個表單對應的欄位與資料列集合。</returns>
+    List<FormListDataViewModel> GetFormList();
     
     /// <summary>
     /// 取得 單一

--- a/Service/Service/FormLogicService/FormFieldMasterService.cs
+++ b/Service/Service/FormLogicService/FormFieldMasterService.cs
@@ -1,8 +1,10 @@
 using ClassLibrary;
 using Dapper;
 using DynamicForm.Models;
+using DynamicForm.ViewModels;
 using DynamicForm.Service.Interface.FormLogicInterface;
 using Microsoft.Data.SqlClient;
+using System.Collections.Generic;
 
 namespace DynamicForm.Service.Service.FormLogicService;
 
@@ -29,23 +31,36 @@ public class FormFieldMasterService : IFormFieldMasterService
             new { id }, transaction: tx);
     }
     
-    public (FORM_FIELD_Master Master, List<string> SchemaColumns, List<FormFieldConfigDto> FieldConfigs) GetFormMetaAggregate(TableSchemaQueryType type)
+    public List<(FORM_FIELD_Master Master, List<FormFieldInputViewModel> FieldConfigRows)> GetFormMetaAggregates(TableSchemaQueryType type)
     {
-        var master = GetFormFieldMaster(type);
-        if (master == null) return default; // 或 return (null, null, null);
+        var masters = _con.Query<FORM_FIELD_Master>(
+            "/**/SELECT * FROM FORM_FIELD_Master WHERE SCHEMA_TYPE = @TYPE",
+            new { TYPE = type.ToInt() })
+            .ToList();
 
-        using var multi = _con.QueryMultiple(@"
-        SELECT * FROM FORM_FIELD_Master WHERE SCHEMA_TYPE = @type;
-        SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @viewTable;
-        SELECT ID, COLUMN_NAME, CONTROL_TYPE FROM FORM_FIELD_CONFIG WHERE FORM_FIELD_Master_ID = @id;
-    ", new { type = type.ToInt(), viewTable = master.VIEW_TABLE_NAME, id = master.BASE_TABLE_ID });
+        var result = new List<(FORM_FIELD_Master, List<FormFieldInputViewModel>)>();
 
-        var masterResult = multi.ReadFirstOrDefault<FORM_FIELD_Master>();
-        var columns = multi.Read<string>().ToList();
-        var configs = multi.Read<FormFieldConfigDto>().ToList();
+        foreach (var master in masters)
+        {
+            var configs = _con.Query<FormFieldInputViewModel>(
+                @"SELECT ID AS FieldConfigId,
+                        COLUMN_NAME AS [Column],
+                        DATA_TYPE,
+                        CONTROL_TYPE,
+                        DEFAULT_VALUE AS DefaultValue,
+                        IS_REQUIRED,
+                        IS_EDITABLE,
+                        ISUSESQL,
+                        DROPDOWNSQL
+                  FROM FORM_FIELD_CONFIG
+                 WHERE FORM_FIELD_Master_ID = @id AND SCHEMA_TYPE = @schemaType",
+                new { id = master.VIEW_TABLE_ID, schemaType = TableSchemaQueryType.OnlyView.ToInt() })
+                .ToList();
 
-        // tuple 直接 return
-        return (masterResult, columns, configs);
+            result.Add((master, configs));
+        }
+
+        return result;
     }
 
 }

--- a/Service/Service/FormService.cs
+++ b/Service/Service/FormService.cs
@@ -8,6 +8,8 @@ using DynamicForm.Service.Interface.TransactionInterface;
 using DynamicForm.ViewModels;
 using Microsoft.Data.SqlClient;
 using System.Data;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DynamicForm.Service.Service;
 
@@ -41,55 +43,62 @@ public class FormService : IFormService
     /// 取得指定 SCHEMA_TYPE 下的表單資料清單，
     /// 已自動將下拉選欄位的值轉為顯示文字（OptionText）
     /// </summary>
-    public FormListDataViewModel GetFormList()
+    public List<FormListDataViewModel> GetFormList()
     {
-        // 1. 查詢主表（Form 設定 Master），根據 SCHEMA_TYPE 取得表單主設定
-        // var master = _formFieldMasterService.GetFormFieldMaster(TableSchemaQueryType.All);
-        //
-        // // [防呆] 找不到主表就直接回傳空的 ViewModel，避免後續 NullReference
-        // if (master == null) 
-        //     return new FormListDataViewModel();
-        //
-        // // 2. 取得檢視表的所有欄位名稱（資料表的 Schema）
-        // var columns = _schemaService.GetFormFieldMaster(master.VIEW_TABLE_NAME);
-        //
-        // // 3. 取得該表單的所有欄位設定（包含型別、控制項型態等）
-        // var fieldConfigs = _formFieldConfigService.GetFormFieldConfig(master.BASE_TABLE_ID);
+        var metas = _formFieldMasterService.GetFormMetaAggregates(TableSchemaQueryType.All);
 
-        var (master, columns, fieldConfigs) = _formFieldMasterService.GetFormMetaAggregate(TableSchemaQueryType.All);
-        
-        // 4. 取得檢視表的所有原始資料（rawRows 為每列 Dictionary<string, object?>）
-        var rawRows = _formDataService.GetRows(master.VIEW_TABLE_NAME);
+        var results = new List<FormListDataViewModel>();
 
-        var pk = _schemaService.GetPrimaryKeyColumn(master.BASE_TABLE_NAME);
-        
-        if (pk == null)
-            throw new InvalidOperationException("No primary key column found");
-        
-        // 5. 將 rawRows 轉換為 FormDataRow（每列帶主鍵 Id 與所有欄位 Cell）
-        //    同時收集所有資料列的主鍵 rowIds
-        var rows = _dropdownService.ToFormDataRows(rawRows, pk, out var rowIds);
-
-        // 6. 若無任何資料列，直接回傳結果，省略後面下拉選查詢
-        if (!rowIds.Any())
-            return new FormListDataViewModel { FormMasterId = master.ID, Columns = columns, Rows = rows };
-        
-        // 7. 取得所有資料列的下拉選答案（一次查全部，不 N+1）
-        var dropdownAnswers = _dropdownService.GetAnswers(rowIds);
-        
-        // 8. 取得所有 OptionId → OptionText 的對照表
-        var optionTextMap = _dropdownService.GetOptionTextMap(dropdownAnswers);
-        
-        // 9. 將 rows 裡所有下拉選欄位的值由 OptionId 轉換為 OptionText（顯示文字）
-        _dropdownService.ReplaceDropdownIdsWithTexts(rows, fieldConfigs, dropdownAnswers, optionTextMap);
-
-        // 10. 組裝並回傳最終的 ViewModel
-        return new FormListDataViewModel
+        foreach (var (master, configRows) in metas)
         {
-            FormMasterId = master.ID,
-            Columns = columns,
-            Rows = rows
-        };
+            var rawConfigs = configRows
+                .Select(cfg => new Dictionary<string, object?>
+                {
+                    ["ID"] = cfg.FieldConfigId,
+                    ["COLUMN_NAME"] = cfg.Column,
+                    ["DATA_TYPE"] = cfg.DATA_TYPE,
+                    ["CONTROL_TYPE"] = cfg.CONTROL_TYPE,
+                    ["DEFAULT_VALUE"] = cfg.DefaultValue,
+                    ["IS_REQUIRED"] = cfg.IS_REQUIRED,
+                    ["IS_EDITABLE"] = cfg.IS_EDITABLE,
+                    ["ISUSESQL"] = cfg.ISUSESQL,
+                    ["DROPDOWNSQL"] = cfg.DROPDOWNSQL
+                } as IDictionary<string, object?>)
+                .ToList();
+
+            var columns = _dropdownService.ToFormDataRows(rawConfigs, "ID", out _);
+
+            var fieldConfigs = configRows.Select(cfg => new FormFieldConfigDto
+            {
+                ID = cfg.FieldConfigId,
+                COLUMN_NAME = cfg.Column,
+                CONTROL_TYPE = cfg.CONTROL_TYPE
+            }).ToList();
+
+            var rawRows = _formDataService.GetRows(master.VIEW_TABLE_NAME);
+            var pk = _schemaService.GetPrimaryKeyColumn(master.BASE_TABLE_NAME);
+
+            if (pk == null)
+                throw new InvalidOperationException("No primary key column found");
+
+            var rows = _dropdownService.ToFormDataRows(rawRows, pk, out var rowIds);
+
+            if (rowIds.Any())
+            {
+                var dropdownAnswers = _dropdownService.GetAnswers(rowIds);
+                var optionTextMap = _dropdownService.GetOptionTextMap(dropdownAnswers);
+                _dropdownService.ReplaceDropdownIdsWithTexts(rows, fieldConfigs, dropdownAnswers, optionTextMap);
+            }
+
+            results.Add(new FormListDataViewModel
+            {
+                FormMasterId = master.ID,
+                Columns = columns,
+                Rows = rows
+            });
+        }
+
+        return results;
     }
 
     /// <summary>

--- a/ViewModels/FormListDataViewModel.cs
+++ b/ViewModels/FormListDataViewModel.cs
@@ -1,5 +1,3 @@
-using DynamicForm.Models;
-
 namespace DynamicForm.ViewModels
 {
     /// <summary>
@@ -8,7 +6,7 @@ namespace DynamicForm.ViewModels
     public class FormListDataViewModel
     {
         public Guid FormMasterId { get; set; }
-        public List<string> Columns { get; set; } = new();
+        public List<FormDataRow> Columns { get; set; } = new();
         public List<FormDataRow> Rows { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- expand GetForms to return multiple form datasets
- support retrieving meta data for all forms and adjust tests
- Columns now return field config rows as `FormDataRow`
- GetFormMetaAggregates now exposes field configs as `FormFieldInputViewModel`

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json; The remote certificate is invalid because of errors in the certificate chain: RevocationStatusUnknown, OfflineRevocation)*

------
https://chatgpt.com/codex/tasks/task_e_6891930836488320a965407e549020b5