### PR TITLE
feat: support query conditions when listing forms

### DIFF
--- a/Controllers/FormController.cs
+++ b/Controllers/FormController.cs
@@ -1,4 +1,5 @@
-﻿using DynamicForm.Service.Interface;
+﻿using DynamicForm.Models;
+using DynamicForm.Service.Interface;
 using DynamicForm.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,10 +19,10 @@ public class FormController : ControllerBase
         _formService = formService;
     }
     
-    [HttpGet]
-    public IActionResult GetForms()
+    [HttpPost("search")]
+    public IActionResult GetForms([FromBody] List<FormQueryCondition>? conditions)
     {
-        var vm = _formService.GetFormList();
+        var vm = _formService.GetFormList(conditions);
         return Ok(vm);
     }
     

--- a/DynamicForm.Tests/ApiControllerTest/FormControllerTests.cs
+++ b/DynamicForm.Tests/ApiControllerTest/FormControllerTests.cs
@@ -1,4 +1,5 @@
 using DynamicForm.Controllers;
+using DynamicForm.Models;
 using DynamicForm.Service.Interface;
 using DynamicForm.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -26,9 +27,9 @@ public class FormControllerTests
     public void GetForms_ReturnsOkWithViewModel()
     {
         var vm = new List<FormListDataViewModel> { new FormListDataViewModel { FormMasterId = Guid.NewGuid() } };
-        _serviceMock.Setup(s => s.GetFormList()).Returns(vm);
+        _serviceMock.Setup(s => s.GetFormList(null)).Returns(vm);
 
-        var result = _controller.GetForms() as OkObjectResult;
+        var result = _controller.GetForms(null) as OkObjectResult;
 
         Assert.NotNull(result);
         Assert.Equal(vm, result.Value);

--- a/DynamicForm.Tests/LogicTest/QueryConditionTests.cs
+++ b/DynamicForm.Tests/LogicTest/QueryConditionTests.cs
@@ -3,6 +3,7 @@ using DynamicForm.Models;
 using DynamicForm.Service.Service;
 using Microsoft.Data.Sqlite;
 using ClassLibrary;
+using Xunit;
 
 namespace DynamicForm.Tests.LogicTest;
 
@@ -42,5 +43,15 @@ public class QueryConditionTests
     private class Config
     {
         public QueryConditionType QUERY_CONDITION_TYPE { get; set; }
+    }
+
+    [Theory]
+    [InlineData(QueryConditionType.Text, ConditionType.Like)]
+    [InlineData(QueryConditionType.Number, ConditionType.Between)]
+    [InlineData(QueryConditionType.Date, ConditionType.Between)]
+    [InlineData(QueryConditionType.Dropdown, ConditionType.Equal)]
+    public void QueryConditionType_MapsToConditionType(QueryConditionType input, ConditionType expected)
+    {
+        Assert.Equal(expected, input.ToConditionType());
     }
 }

--- a/Enum/ConditionType.cs
+++ b/Enum/ConditionType.cs
@@ -1,0 +1,14 @@
+namespace ClassLibrary;
+
+/// <summary>
+/// 查詢條件的運算子類型。
+/// </summary>
+public enum ConditionType
+{
+    /// <summary>等於</summary>
+    Equal,
+    /// <summary>模糊比對</summary>
+    Like,
+    /// <summary>區間比對</summary>
+    Between
+}

--- a/Enum/QueryConditionTypeExtensions.cs
+++ b/Enum/QueryConditionTypeExtensions.cs
@@ -1,0 +1,25 @@
+using ClassLibrary;
+
+namespace ClassLibrary;
+
+/// <summary>
+/// 提供 <see cref="QueryConditionType"/> 與 <see cref="ConditionType"/> 之間的轉換。
+/// </summary>
+public static class QueryConditionTypeExtensions
+{
+    /// <summary>
+    /// 將查詢元件類型對應到 SQL 運算子類型。
+    /// </summary>
+    /// <param name="type">介面上的查詢元件類型。</param>
+    /// <returns>對應的運算子類型。</returns>
+    public static ConditionType ToConditionType(this QueryConditionType type) => type switch
+    {
+        // 文字輸入通常做模糊搜尋
+        QueryConditionType.Text => ConditionType.Like,
+        // 數字與日期多半用於區間比對，若前端只提供單一值仍可重用 Between 的邏輯
+        QueryConditionType.Number => ConditionType.Between,
+        QueryConditionType.Date => ConditionType.Between,
+        // 下拉與未指定則採等於比較
+        _ => ConditionType.Equal
+    };
+}

--- a/Models/FormQueryCondition.cs
+++ b/Models/FormQueryCondition.cs
@@ -1,0 +1,34 @@
+using ClassLibrary;
+
+namespace DynamicForm.Models;
+
+/// <summary>
+/// 描述查詢條件的資料模型。
+/// </summary>
+public class FormQueryCondition
+{
+    /// <summary>要比對的欄位名稱。</summary>
+    public string Column { get; set; } = string.Empty;
+
+    /// <summary>比對運算子。</summary>
+    public ConditionType ConditionType { get; set; }
+        = ConditionType.Equal;
+
+    /// <summary>
+    /// 查詢元件類型，可由此自動推斷 <see cref="ConditionType"/>。
+    /// 若同時指定， <see cref="ConditionType"/> 優先。
+    /// </summary>
+    public QueryConditionType? QueryConditionType { get; set; }
+        = null;
+
+    /// <summary>主要的比對值。</summary>
+    public string? Value { get; set; }
+        = string.Empty;
+
+    /// <summary>區間比對的第二個值。</summary>
+    public string? Value2 { get; set; }
+        = string.Empty;
+
+    /// <summary>欄位的 SQL 資料型別，用於轉型。</summary>
+    public string DataType { get; set; } = string.Empty;
+}

--- a/Service/Interface/FormLogicInterface/IFormDataService.cs
+++ b/Service/Interface/FormLogicInterface/IFormDataService.cs
@@ -5,7 +5,13 @@ namespace DynamicForm.Service.Interface.FormLogicInterface;
 
 public interface IFormDataService
 {
-    List<IDictionary<string, object?>> GetRows(string tableName);
+    /// <summary>
+    /// 取得資料列，允許依條件過濾。
+    /// </summary>
+    /// <param name="tableName">目標資料表或檢視表名稱。</param>
+    /// <param name="conditions">查詢條件集合。</param>
+    /// <returns>符合條件的資料列。</returns>
+    List<IDictionary<string, object?>> GetRows(string tableName, IEnumerable<FormQueryCondition>? conditions = null);
 
     Dictionary<string, string> LoadColumnTypes(string tableName);
 }

--- a/Service/Interface/IFormService.cs
+++ b/Service/Interface/IFormService.cs
@@ -1,4 +1,5 @@
-﻿using DynamicForm.ViewModels;
+﻿using DynamicForm.Models;
+using DynamicForm.ViewModels;
 using System.Collections.Generic;
 
 namespace DynamicForm.Service.Interface;
@@ -8,8 +9,9 @@ public interface IFormService
     /// <summary>
     /// 取得所有表單的資料列表。
     /// </summary>
+    /// <param name="conditions">查詢條件集合。</param>
     /// <returns>每個表單對應的欄位與資料列集合。</returns>
-    List<FormListDataViewModel> GetFormList();
+    List<FormListDataViewModel> GetFormList(IEnumerable<FormQueryCondition>? conditions = null);
     
     /// <summary>
     /// 取得 單一

--- a/Service/Service/FormService.cs
+++ b/Service/Service/FormService.cs
@@ -41,9 +41,9 @@ public class FormService : IFormService
 
     /// <summary>
     /// 取得指定 SCHEMA_TYPE 下的表單資料清單，
-    /// 已自動將下拉選欄位的值轉為顯示文字（OptionText）
+    /// 已自動將下拉選欄位的值轉為顯示文字（OptionText）。
     /// </summary>
-    public List<FormListDataViewModel> GetFormList()
+    public List<FormListDataViewModel> GetFormList(IEnumerable<FormQueryCondition>? conditions = null)
     {
         var metas = _formFieldMasterService.GetFormMetaAggregates(TableSchemaQueryType.All);
 
@@ -51,7 +51,7 @@ public class FormService : IFormService
 
         foreach (var (master, columns, fieldConfigs) in metas)
         {
-            var rawRows = _formDataService.GetRows(master.VIEW_TABLE_NAME);
+            var rawRows = _formDataService.GetRows(master.VIEW_TABLE_NAME, conditions);
             var pk = _schemaService.GetPrimaryKeyColumn(master.BASE_TABLE_NAME);
 
             if (pk == null)


### PR DESCRIPTION
## Summary
- add `ConditionType` enum and `FormQueryCondition` model
- build SQL dynamically in `FormDataService` to handle Equal/Like/Between
- allow `FormService` and `FormController` to accept query conditions when fetching forms
- map UI `QueryConditionType` to SQL `ConditionType` for easier configuration

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891bdb0d56083209cc74fedf30d1b46