### PR TITLE
feat: add field lookup by ID

### DIFF
--- a/Controllers/FormDesignerController.cs
+++ b/Controllers/FormDesignerController.cs
@@ -60,14 +60,16 @@ public class FormDesignerController : ControllerBase
     }
 
     /// <summary>
-    /// 取得單一欄位設定
+    /// 依欄位設定 ID 取得單一欄位設定
     /// </summary>
-    [HttpGet("tables/{tableName}/fields/{columnName}")]
-    public IActionResult GetField(string tableName, string columnName, [FromQuery] TableSchemaQueryType schemaType)
+    /// <param name="fieldId">欄位設定唯一識別碼</param>
+    /// <param name="schemaType">資料表查詢類型</param>
+    [HttpGet("fields/{fieldId}")]
+    public IActionResult GetField(Guid fieldId, [FromQuery] TableSchemaQueryType schemaType)
     {
-        var field = _formDesignerService
-                    .GetFieldsByTableName(tableName, schemaType)
-                    .Fields.FirstOrDefault(x => x.COLUMN_NAME == columnName);
+        var field = _formDesignerService.GetFieldById(fieldId);
+        if (field == null) return NotFound();
+        field.SchemaType = schemaType;
         return Ok(field);
     }
 

--- a/DynamicForm.Tests/ApiControllerTest/FormDesignerControllerTests.cs
+++ b/DynamicForm.Tests/ApiControllerTest/FormDesignerControllerTests.cs
@@ -147,6 +147,33 @@ public class FormDesignerControllerTests
     }
 
     [Fact]
+    public void GetField_ById_ReturnsField()
+    {
+        var controller = CreateController();
+        var fieldId = Guid.NewGuid();
+        var field = new FormFieldViewModel { ID = fieldId };
+        _designerMock.Setup(s => s.GetFieldById(fieldId)).Returns(field);
+
+        var result = controller.GetField(fieldId, TableSchemaQueryType.OnlyTable) as OkObjectResult;
+
+        Assert.NotNull(result);
+        var model = Assert.IsType<FormFieldViewModel>(result.Value);
+        Assert.Equal(TableSchemaQueryType.OnlyTable, model.SchemaType);
+    }
+
+    [Fact]
+    public void GetField_ById_NotFound()
+    {
+        var controller = CreateController();
+        var fieldId = Guid.NewGuid();
+        _designerMock.Setup(s => s.GetFieldById(fieldId)).Returns((FormFieldViewModel?)null);
+
+        var result = controller.GetField(fieldId, TableSchemaQueryType.OnlyTable);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
     public void UpsertField_MissingSystemColumns_ReturnsBadRequest()
     {
         var controller = CreateController();

--- a/Service/Interface/IFormDesignerService.cs
+++ b/Service/Interface/IFormDesignerService.cs
@@ -11,6 +11,13 @@ public interface IFormDesignerService
     FormFieldListViewModel? EnsureFieldsSaved(string tableName, TableSchemaQueryType type);
     FormFieldListViewModel GetFieldsByTableName(string tableName, TableSchemaQueryType schemaType);
 
+    /// <summary>
+    /// 依欄位設定 ID 取得單一欄位設定。
+    /// </summary>
+    /// <param name="fieldId">欄位設定唯一識別碼</param>
+    /// <returns>若找到欄位則回傳 <see cref="FormFieldViewModel"/>；否則回傳 null。</returns>
+    FormFieldViewModel? GetFieldById(Guid fieldId);
+
     void UpsertField(FormFieldViewModel model, Guid formMasterId);
 
     /// <summary>

--- a/Service/Service/FormDesignerService.cs
+++ b/Service/Service/FormDesignerService.cs
@@ -139,6 +139,40 @@ public class FormDesignerService : IFormDesignerService
     }
 
     /// <summary>
+    /// 依欄位設定 ID 取得單一欄位設定。
+    /// </summary>
+    /// <param name="fieldId">欄位設定唯一識別碼</param>
+    /// <returns>若找到欄位則回傳 <see cref="FormFieldViewModel"/>；否則回傳 null。</returns>
+    public FormFieldViewModel? GetFieldById(Guid fieldId)
+    {
+        var cfg = _con.QueryFirstOrDefault<FormFieldConfigDto>(
+            Sql.FieldConfigSelect + " WHERE ID = @fieldId", new { fieldId });
+        if (cfg == null) return null;
+
+        var pk = _schemaService.GetPrimaryKeyColumns(cfg.TABLE_NAME);
+
+        return new FormFieldViewModel
+        {
+            ID = cfg.ID,
+            FORM_FIELD_Master_ID = cfg.FORM_FIELD_Master_ID,
+            TableName = cfg.TABLE_NAME,
+            COLUMN_NAME = cfg.COLUMN_NAME,
+            DATA_TYPE = cfg.DATA_TYPE,
+            CONTROL_TYPE = cfg.CONTROL_TYPE,
+            CONTROL_TYPE_WHITELIST = FormFieldHelper.GetControlTypeWhitelist(cfg.DATA_TYPE),
+            IS_REQUIRED = cfg.IS_REQUIRED,
+            IS_EDITABLE = cfg.IS_EDITABLE,
+            IS_VALIDATION_RULE = HasValidationRules(cfg.ID),
+            IS_PK = pk.Contains(cfg.COLUMN_NAME),
+            DEFAULT_VALUE = cfg.DEFAULT_VALUE ?? string.Empty,
+            FIELD_ORDER = cfg.FIELD_ORDER,
+            QUERY_CONDITION_TYPE = cfg.QUERY_CONDITION_TYPE,
+            QUERY_CONDITION_SQL = cfg.QUERY_CONDITION_SQL ?? string.Empty,
+            CAN_QUERY = cfg.CAN_QUERY
+        };
+    }
+
+    /// <summary>
     /// 搜尋表格時，如設定檔不存在則先寫入預設欄位設定。
     /// </summary>
     /// <param name="tableName">資料表名稱</param>


### PR DESCRIPTION
## Summary
- support fetching single field settings using its unique ID
- implement service method to retrieve field by ID
- cover new endpoint with controller tests

## Testing
- `dotnet test` *(fails: Microsoft.Build.Exceptions.InternalLoggerException: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_6895ae07b548832091d7a6db89dcb2dd