### PR TITLE
Add duplicate name checks for permission management

### DIFF
--- a/Areas/Permission/Controllers/PermissionManagementController.cs
+++ b/Areas/Permission/Controllers/PermissionManagementController.cs
@@ -116,6 +116,9 @@ namespace DynamicForm.Areas.Permission.Controllers
             if (!System.Enum.IsDefined(typeof(ActionType), request.Code))
                 return ValidationProblem($"Invalid ActionType: {request.Code}");
 
+            if (await _permissionService.PermissionCodeExistsAsync(request.Code))
+                return Conflict($"權限碼已存在: {request.Code}");
+
             var id = await _permissionService.CreatePermissionAsync(request.Code);
             var result = new PermissionModel { Id = id, Code = request.Code };
             return CreatedAtAction(nameof(GetPermission), new { id }, result);
@@ -143,6 +146,9 @@ namespace DynamicForm.Areas.Permission.Controllers
 
             if (await _permissionService.GetPermissionAsync(id) is null)
                 return NotFound();
+
+            if (await _permissionService.PermissionCodeExistsAsync(request.Code, id))
+                return Conflict($"權限碼已存在: {request.Code}");
 
             await _permissionService.UpdatePermissionAsync(new PermissionModel { Id = id, Code = request.Code });
             return NoContent();

--- a/Areas/Permission/Controllers/PermissionManagementController.cs
+++ b/Areas/Permission/Controllers/PermissionManagementController.cs
@@ -53,6 +53,9 @@ namespace DynamicForm.Areas.Permission.Controllers
         public async Task<ActionResult<Group>> CreateGroup([FromBody] CreateGroupRequest request)
         {
             // 基礎驗證由 [ApiController] 自動處理；此處直入業務流程
+            if (await _permissionService.GroupNameExistsAsync(request.Name))
+                return Conflict($"群組名稱已存在: {request.Name}");
+
             var id = await _permissionService.CreateGroupAsync(request.Name);
             var result = new Group { Id = id, Name = request.Name };
 
@@ -79,6 +82,9 @@ namespace DynamicForm.Areas.Permission.Controllers
             // 前置檢查：不存在就 404，避免「成功但其實沒更新」
             if (await _permissionService.GetGroupAsync(id) is null)
                 return NotFound();
+
+            if (await _permissionService.GroupNameExistsAsync(request.Name, id))
+                return Conflict($"群組名稱已存在: {request.Name}");
 
             await _permissionService.UpdateGroupAsync(new Group { Id = id, Name = request.Name });
             return NoContent();
@@ -165,6 +171,9 @@ namespace DynamicForm.Areas.Permission.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<Function>> CreateFunction([FromBody] CreateFunctionRequest request)
         {
+            if (await _permissionService.FunctionNameExistsAsync(request.Name))
+                return Conflict($"功能名稱已存在: {request.Name}");
+
             var id = await _permissionService.CreateFunctionAsync(new Function
             {
                 Name = request.Name,
@@ -194,6 +203,9 @@ namespace DynamicForm.Areas.Permission.Controllers
         {
             if (await _permissionService.GetFunctionAsync(id) is null)
                 return NotFound();
+
+            if (await _permissionService.FunctionNameExistsAsync(request.Name, id))
+                return Conflict($"功能名稱已存在: {request.Name}");
 
             await _permissionService.UpdateFunctionAsync(new Function
             {
@@ -229,6 +241,9 @@ namespace DynamicForm.Areas.Permission.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<Menu>> CreateMenu([FromBody] CreateMenuRequest request)
         {
+            if (await _permissionService.MenuNameExistsAsync(request.Name, request.ParentId))
+                return Conflict($"選單名稱已存在: {request.Name}");
+
             var id = await _permissionService.CreateMenuAsync(new Menu
             {
                 ParentId = request.ParentId,
@@ -269,6 +284,9 @@ namespace DynamicForm.Areas.Permission.Controllers
         {
             if (await _permissionService.GetMenuAsync(id) is null)
                 return NotFound();
+
+            if (await _permissionService.MenuNameExistsAsync(request.Name, request.ParentId, id))
+                return Conflict($"選單名稱已存在: {request.Name}");
 
             await _permissionService.UpdateMenuAsync(new Menu
             {

--- a/Areas/Permission/Interfaces/IPermissionService.cs
+++ b/Areas/Permission/Interfaces/IPermissionService.cs
@@ -13,6 +13,7 @@ namespace DynamicForm.Areas.Permission.Interfaces
         Task<Group?> GetGroupAsync(Guid id);
         Task UpdateGroupAsync(Group group);
         Task DeleteGroupAsync(Guid id);
+        Task<bool> GroupNameExistsAsync(string name, Guid? excludeId = null);
 
         // 權限
         Task<Guid> CreatePermissionAsync(ActionType code);
@@ -25,12 +26,14 @@ namespace DynamicForm.Areas.Permission.Interfaces
         Task<Function?> GetFunctionAsync(Guid id);
         Task UpdateFunctionAsync(Function function);
         Task DeleteFunctionAsync(Guid id);
+        Task<bool> FunctionNameExistsAsync(string name, Guid? excludeId = null);
 
         // 選單
         Task<Guid> CreateMenuAsync(Menu menu);
         Task<Menu?> GetMenuAsync(Guid id);
         Task UpdateMenuAsync(Menu menu);
         Task DeleteMenuAsync(Guid id);
+        Task<bool> MenuNameExistsAsync(string name, Guid? parentId, Guid? excludeId = null);
 
         // 使用者與群組關聯
         Task AssignUserToGroupAsync(Guid userId, Guid groupId);

--- a/Areas/Permission/Interfaces/IPermissionService.cs
+++ b/Areas/Permission/Interfaces/IPermissionService.cs
@@ -20,6 +20,7 @@ namespace DynamicForm.Areas.Permission.Interfaces
         Task<PermissionModel?> GetPermissionAsync(Guid id);
         Task UpdatePermissionAsync(PermissionModel permission);
         Task DeletePermissionAsync(Guid id);
+        Task<bool> PermissionCodeExistsAsync(ActionType code, Guid? excludeId = null);
 
         // 功能
         Task<Guid> CreateFunctionAsync(Function function);

--- a/Areas/Permission/Services/PermissionService.cs
+++ b/Areas/Permission/Services/PermissionService.cs
@@ -130,6 +130,20 @@ namespace DynamicForm.Areas.Permission.Services
             return _con.ExecuteAsync(sql, new { Id = id });
         }
 
+        /// <summary>
+        /// 檢查權限碼是否已存在。
+        /// </summary>
+        public async Task<bool> PermissionCodeExistsAsync(ActionType code, Guid? excludeId = null)
+        {
+            const string sql =
+                @"SELECT COUNT(1)
+                    FROM SYS_PERMISSION
+                    WHERE CODE = @Code AND IS_ACTIVE = 1
+                      AND (@ExcludeId IS NULL OR ID <> @ExcludeId)";
+            var count = await _con.ExecuteScalarAsync<int>(sql, new { Code = code, ExcludeId = excludeId });
+            return count > 0;
+        }
+
         #endregion
 
         #region 功能 CRUD

--- a/Areas/Permission/Services/PermissionService.cs
+++ b/Areas/Permission/Services/PermissionService.cs
@@ -72,6 +72,20 @@ namespace DynamicForm.Areas.Permission.Services
             return _con.ExecuteAsync(sql, new { Id = id });
         }
 
+        /// <summary>
+        /// 檢查群組名稱是否已存在。
+        /// </summary>
+        public async Task<bool> GroupNameExistsAsync(string name, Guid? excludeId = null)
+        {
+            const string sql =
+                @"SELECT COUNT(1)
+                    FROM SYS_GROUP
+                    WHERE NAME = @Name AND IS_ACTIVE = 1
+                      AND (@ExcludeId IS NULL OR ID <> @ExcludeId)";
+            var count = await _con.ExecuteScalarAsync<int>(sql, new { Name = name, ExcludeId = excludeId });
+            return count > 0;
+        }
+
         #endregion
 
         #region 權限 CRUD
@@ -178,6 +192,20 @@ namespace DynamicForm.Areas.Permission.Services
             return _con.ExecuteAsync(sql, new { Id = id });
         }
 
+        /// <summary>
+        /// 檢查功能名稱是否已存在。
+        /// </summary>
+        public async Task<bool> FunctionNameExistsAsync(string name, Guid? excludeId = null)
+        {
+            const string sql =
+                @"SELECT COUNT(1)
+                    FROM SYS_FUNCTION
+                    WHERE NAME = @Name AND IS_DELETE = 0
+                      AND (@ExcludeId IS NULL OR ID <> @ExcludeId)";
+            var count = await _con.ExecuteScalarAsync<int>(sql, new { Name = name, ExcludeId = excludeId });
+            return count > 0;
+        }
+
         #endregion
 
         #region 選單 CRUD
@@ -247,6 +275,21 @@ namespace DynamicForm.Areas.Permission.Services
         {
             const string sql = @"UPDATE SYS_MENU SET IS_DELETE = 1 WHERE ID = @Id";
             return _con.ExecuteAsync(sql, new { Id = id });
+        }
+
+        /// <summary>
+        /// 檢查同層級選單名稱是否重複。
+        /// </summary>
+        public async Task<bool> MenuNameExistsAsync(string name, Guid? parentId, Guid? excludeId = null)
+        {
+            const string sql =
+                @"SELECT COUNT(1)
+                    FROM SYS_MENU
+                    WHERE NAME = @Name AND IS_DELETE = 0
+                      AND ((@ParentId IS NULL AND PARENT_ID IS NULL) OR PARENT_ID = @ParentId)
+                      AND (@ExcludeId IS NULL OR ID <> @ExcludeId)";
+            var count = await _con.ExecuteScalarAsync<int>(sql, new { Name = name, ParentId = parentId, ExcludeId = excludeId });
+            return count > 0;
         }
 
         #endregion

--- a/DynamicForm.Tests/ApiControllerTest/PermissionManagementControllerTests.cs
+++ b/DynamicForm.Tests/ApiControllerTest/PermissionManagementControllerTests.cs
@@ -1,0 +1,100 @@
+using DynamicForm.Areas.Permission.Controllers;
+using DynamicForm.Areas.Permission.Interfaces;
+using DynamicForm.Areas.Permission.Models;
+using DynamicForm.Areas.Permission.ViewModels.PermissionManagement;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using System;
+
+namespace DynamicForm.Tests.ApiControllerTest;
+
+/// <summary>
+/// 測試 <see cref="PermissionManagementController"/> 在新增與更新時對於重複名稱的處理。
+/// </summary>
+public class PermissionManagementControllerTests
+{
+    private readonly Mock<IPermissionService> _service = new();
+
+    private PermissionManagementController CreateController()
+        => new(_service.Object);
+
+    [Fact]
+    public async Task CreateGroup_Duplicate_ReturnsConflict()
+    {
+        var request = new CreateGroupRequest { Name = "G" };
+        _service.Setup(s => s.GroupNameExistsAsync("G", null)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.CreateGroup(request);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdateGroup_Duplicate_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var request = new UpdateGroupRequest { Name = "G" };
+        _service.Setup(s => s.GetGroupAsync(id)).ReturnsAsync(new Group { Id = id, Name = "Old" });
+        _service.Setup(s => s.GroupNameExistsAsync("G", id)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.UpdateGroup(id, request);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task CreateFunction_Duplicate_ReturnsConflict()
+    {
+        var request = new CreateFunctionRequest { Name = "F", Area = "A", Controller = "C" };
+        _service.Setup(s => s.FunctionNameExistsAsync("F", null)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.CreateFunction(request);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdateFunction_Duplicate_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var request = new UpdateFunctionRequest { Name = "F", Area = "A", Controller = "C" };
+        _service.Setup(s => s.GetFunctionAsync(id)).ReturnsAsync(new Function { Id = id, Name = "Old", Area = "A", Controller = "C" });
+        _service.Setup(s => s.FunctionNameExistsAsync("F", id)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.UpdateFunction(id, request);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task CreateMenu_Duplicate_ReturnsConflict()
+    {
+        var request = new CreateMenuRequest { ParentId = null, SysFunctionId = Guid.NewGuid(), Name = "M", Sort = 1, IsShare = false };
+        _service.Setup(s => s.MenuNameExistsAsync("M", null, null)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.CreateMenu(request);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdateMenu_Duplicate_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var request = new UpdateMenuRequest { ParentId = null, SysFunctionId = Guid.NewGuid(), Name = "M", Sort = 1, IsShare = false };
+        _service.Setup(s => s.GetMenuAsync(id)).ReturnsAsync(new Menu { Id = id, ParentId = null, SysFunctionId = request.SysFunctionId, Name = "Old", Sort = 1, IsShare = false });
+        _service.Setup(s => s.MenuNameExistsAsync("M", null, id)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.UpdateMenu(id, request);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+}
+

--- a/DynamicForm.Tests/ApiControllerTest/PermissionManagementControllerTests.cs
+++ b/DynamicForm.Tests/ApiControllerTest/PermissionManagementControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using System;
+using ClassLibrary;
 
 namespace DynamicForm.Tests.ApiControllerTest;
 
@@ -93,6 +94,32 @@ public class PermissionManagementControllerTests
         var controller = CreateController();
 
         var result = await controller.UpdateMenu(id, request);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task CreatePermission_Duplicate_ReturnsConflict()
+    {
+        var request = new CreatePermissionRequest { Code = ActionType.Create };
+        _service.Setup(s => s.PermissionCodeExistsAsync(ActionType.Create, null)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.CreatePermission(request);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdatePermission_Duplicate_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var request = new UpdatePermissionRequest { Code = ActionType.Create };
+        _service.Setup(s => s.GetPermissionAsync(id)).ReturnsAsync(new PermissionModel { Id = id, Code = ActionType.Read });
+        _service.Setup(s => s.PermissionCodeExistsAsync(ActionType.Create, id)).ReturnsAsync(true);
+        var controller = CreateController();
+
+        var result = await controller.UpdatePermission(id, request);
 
         Assert.IsType<ConflictObjectResult>(result);
     }


### PR DESCRIPTION
## Summary
- prevent duplicate group names during creation and update
- block duplicate function and menu names with service-level checks
- add controller unit tests for duplicate name conflicts

## Testing
- `dotnet test --logger:"console;verbosity=minimal"` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c26a80f748320bf40163a93b83cf6