### PR TITLE
feat: categorize swagger docs

### DIFF
--- a/Areas/ApiStats/Controllers/ApiStatsController.cs
+++ b/Areas/ApiStats/Controllers/ApiStatsController.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.ApiStats.Controllers
 {
@@ -9,6 +10,7 @@ namespace DynamicForm.Areas.ApiStats.Controllers
     /// 此段純 GPT 生成，方便參考而已，不需維護
     /// </summary>
     [ApiController]
+    [ApiExplorerSettings(GroupName = SwaggerGroups.ApiStats)]
     [Route("tools/apistats")]
     [Produces("application/json")]
     public class ApiStatsController : ControllerBase

--- a/Areas/Enum/Controllers/EnumListController.cs
+++ b/Areas/Enum/Controllers/EnumListController.cs
@@ -2,6 +2,7 @@ using ClassLibrary;
 using DynamicForm.Areas.Enum.Interfaces;
 using DynamicForm.Areas.Enum.Models;
 using Microsoft.AspNetCore.Mvc;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.Enum.Controllers;
 
@@ -10,6 +11,7 @@ namespace DynamicForm.Areas.Enum.Controllers;
 /// </summary>
 [Area("Enum")]
 [ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.Enum)]
 [Route("[area]/[controller]")]
 public class EnumListController : ControllerBase
 {

--- a/Areas/Form/Controllers/FormController.cs
+++ b/Areas/Form/Controllers/FormController.cs
@@ -2,6 +2,7 @@ using DynamicForm.Areas.Form.Models;
 using DynamicForm.Areas.Form.Interfaces;
 using DynamicForm.Areas.Form.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.Form.Controllers;
 
@@ -10,6 +11,7 @@ namespace DynamicForm.Areas.Form.Controllers;
 /// </summary>
 [Area("Form")]
 [ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.Form)]
 [Route("[area]/[controller]")]
 public class FormController : ControllerBase
 {

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -11,6 +11,7 @@ namespace DynamicForm.Areas.Form.Controllers;
 
 [Area("Form")]
 [ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.Form)]
 [Route("[area]/[controller]")]
 public class FormDesignerController : ControllerBase
 {

--- a/Areas/Form/Controllers/FormListController.cs
+++ b/Areas/Form/Controllers/FormListController.cs
@@ -1,6 +1,7 @@
 using DynamicForm.Areas.Form.Models;
 using DynamicForm.Areas.Form.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.Form.Controllers;
 
@@ -9,6 +10,7 @@ namespace DynamicForm.Areas.Form.Controllers;
 /// </summary>
 [Area("Form")]
 [ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.Form)]
 [Route("[area]/[controller]")]
 public class FormListController : ControllerBase
 {

--- a/Areas/Permission/Controllers/PermissionManagementController.cs
+++ b/Areas/Permission/Controllers/PermissionManagementController.cs
@@ -4,6 +4,7 @@ using DynamicForm.Areas.Permission.Models;
 using DynamicForm.Areas.Permission.ViewModels.PermissionManagement;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.Permission.Controllers
 {
@@ -12,6 +13,7 @@ namespace DynamicForm.Areas.Permission.Controllers
     /// </summary>
     [Area("Permission")]
     [ApiController]
+    [ApiExplorerSettings(GroupName = SwaggerGroups.Permission)]
     [Route("[area]/[controller]")]
     [Produces("application/json")]
     public class PermissionManagementController : ControllerBase

--- a/Areas/Security/Controllers/LoginController.cs
+++ b/Areas/Security/Controllers/LoginController.cs
@@ -1,6 +1,7 @@
 using DynamicForm.Areas.Security.Interfaces;
 using DynamicForm.Areas.Security.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using DynamicForm.Helper;
 
 namespace DynamicForm.Areas.Security.Controllers
 {
@@ -9,6 +10,7 @@ namespace DynamicForm.Areas.Security.Controllers
     /// </summary>
     [Area("Security")]
     [ApiController]
+    [ApiExplorerSettings(GroupName = SwaggerGroups.Security)]
     [Route("[area]/[controller]")]
     public class LoginController : ControllerBase
     {

--- a/Areas/Security/Controllers/SecureDataController.cs
+++ b/Areas/Security/Controllers/SecureDataController.cs
@@ -9,11 +9,12 @@ namespace DynamicForm.Areas.Security.Controllers
     /// <summary>
     /// 需要 JWT 授權才能存取的範例端點。
     /// </summary>
-    [Area("Security")]
-    [Authorize]
-    [ApiController]
-    [Route("[area]/[controller]")]
-    public class SecureDataController : ControllerBase
+[Area("Security")]
+[Authorize]
+[ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.Security)]
+[Route("[area]/[controller]")]
+public class SecureDataController : ControllerBase
     {
         /// <summary>
         /// 取得受保護的資料。

--- a/Helper/SwaggerGroups.cs
+++ b/Helper/SwaggerGroups.cs
@@ -1,0 +1,13 @@
+namespace DynamicForm.Helper;
+
+/// <summary>
+/// Swagger 文件的分類常數，避免重複字串與易於維護。
+/// </summary>
+public static class SwaggerGroups
+{
+    public const string Form = nameof(Form);
+    public const string Permission = nameof(Permission);
+    public const string Security = nameof(Security);
+    public const string Enum = nameof(Enum);
+    public const string ApiStats = nameof(ApiStats);
+}


### PR DESCRIPTION
## Summary
- organize Swagger UI into area-based groups for clearer API docs
- centralize group names in `SwaggerGroups` constants

## Testing
- `dotnet build` *(fails: Microsoft.Build.Exceptions.InternalLoggerException)*
- `dotnet test` *(fails: Microsoft.Build.Exceptions.InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_689c3019fd248320b7361eceb4b9c13b